### PR TITLE
Chosfox Geonix Rev.2: Fix wireless mode and RGB state not persisting across power cycles

### DIFF
--- a/keyboards/chosfox/geonixr2/config.h
+++ b/keyboards/chosfox/geonixr2/config.h
@@ -56,10 +56,15 @@
 #define RGB_MATRIX_SLEEP
 
 // BLE configuration for GEONIXR2
-#define USER_BLE_ID (0X00A5) // GEONIXR2 BLE ID
-#define USER_BLE1_NAME "GEONIXR2-1"
-#define USER_BLE2_NAME "GEONIXR2-2"
-#define USER_BLE3_NAME "GEONIXR2-3"
+#define USER_BLE_ID (0x2052) // Geonix R2 BLE ID (matches vendor firmware)
+#define USER_BLE1_NAME "Geonix rev.2-1"
+#define USER_BLE2_NAME "Geonix rev.2-2"
+#define USER_BLE3_NAME "Geonix rev.2-3"
+
+// This board has no physical 3-position mode switch (USB/BLE/2.4G).
+// Without this, the library reads floating GPIO pins on every boot and
+// overrides the saved wireless mode back to USB.
+#define HAS_MODE_SWITCH 0
 
 // LED Index Definitions for keyboard_common library
 #define LED_CONNECTION_INDEX 11 // Connection type indicator (BLE/2.4G/USB)
@@ -70,4 +75,4 @@
 #define LED_BLE_2_INDEX 2       // 'W' key position
 #define LED_BLE_3_INDEX 3       // 'E' key position
 #define LED_2P4G_INDEX 4        // 'R' key position
-#define LED_USB_INDEX 5         // 'T' key position
+#define LED_USB_INDEX 0         // 'Tab' key position

--- a/keyboards/chosfox/geonixr2/geonixr2.c
+++ b/keyboards/chosfox/geonixr2/geonixr2.c
@@ -64,33 +64,133 @@ led_config_t g_led_config = {
 // clang-format on
 
 // ============================================================================
+// RM_TOGG "fake off" — keep RGB matrix enabled for indicator callbacks
+// ============================================================================
+//
+// QMK skips rgb_matrix_indicators_advanced_kb() when effect == 0, which
+// happens when rgb_matrix_config.enable is false (i.e. after RM_TOGG off).
+// The stock firmware's blob drives indicators independently, but the
+// open-source library relies on QMK's callback.
+//
+// Fix: intercept RM_TOGG to toggle a flag instead of truly disabling RGB.
+// When the flag is set, the indicator callback blacks out all LEDs before
+// the library draws its indicators.  The effect is also switched to
+// RGB_MATRIX_SOLID_COLOR (the cheapest possible mode) to minimize CPU
+// and DMA overhead while the LEDs appear off.  The previous effect mode
+// is saved and restored when the user toggles back on.  On boot, if
+// EEPROM already has RGB disabled, force-enable and start in fake-off.
+//
+// Both the fake-off flag and saved mode are persisted in QMK's KB-level
+// eeconfig datablock (EECONFIG_KB_DATA_SIZE = 1) so the state survives
+// power cycles and sleep/wake.
+
+// Persisted via QMK's KB-level eeconfig datablock (EECONFIG_KB_DATA_SIZE = 1).
+typedef union {
+    uint8_t raw;
+    struct {
+        bool    rgb_effects_off : 1;
+        uint8_t rgb_saved_mode  : 7;  // 0-127 covers all RGB_MATRIX_* modes
+    };
+} kb_config_t;
+
+static kb_config_t kb_config;
+
+// ============================================================================
 // QMK Callback Functions - Delegate to common implementations
 // ============================================================================
 
 bool rgb_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max) {
-    return kb_rgb_matrix_indicators_common(led_min, led_max);
+    // In fake-off mode: black out every LED the effect just painted,
+    // then let the library draw indicators on top.
+    if (kb_config.rgb_effects_off) {
+        for (uint8_t i = led_min; i < led_max; i++) {
+            kb_led_off(i);
+        }
+    }
+    if (!kb_rgb_matrix_indicators_common(led_min, led_max)) {
+        return false;
+    }
+    return rgb_matrix_indicators_advanced_user(led_min, led_max);
 }
 
 void notify_usb_device_state_change_kb(struct usb_device_state usb_device_state) {
     kb_notify_usb_device_state_change(usb_device_state);
+    notify_usb_device_state_change_user(usb_device_state);
 }
 
 bool led_update_kb(led_t led_state) {
-    return kb_led_update(led_state);
+    if (!kb_led_update(led_state)) {
+        return false;
+    }
+    return led_update_user(led_state);
 }
 
 void housekeeping_task_kb(void) {
     kb_housekeeping_task();
+    housekeeping_task_user();
 }
 
 void board_init(void) {
     kb_board_init();
 }
 
+void eeconfig_init_kb(void) {
+    // Called on EEPROM reset (EE_CLR).  Zero the KB datablock so RGB
+    // starts with effects ON and no stale saved mode.
+    kb_config.raw = 0;
+    eeconfig_update_kb_datablock(&kb_config, 0, sizeof(kb_config));
+    eeconfig_init_user();
+}
+
 void keyboard_post_init_kb(void) {
     kb_keyboard_post_init();
+
+    // Restore persisted fake-off state from KB datablock.
+    eeconfig_read_kb_datablock(&kb_config, 0, sizeof(kb_config));
+
+    if (kb_config.rgb_effects_off) {
+        // User toggled LEDs off before last power-down — resume fake-off.
+        if (!rgb_matrix_is_enabled()) {
+            rgb_matrix_enable_noeeprom();
+        }
+        rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
+    } else if (!rgb_matrix_is_enabled()) {
+        // Legacy: EEPROM has RGB truly disabled (from before fake-off fix).
+        // Force-enable so indicators work, and start in fake-off.
+        rgb_matrix_enable_noeeprom();
+        kb_config.rgb_effects_off = true;
+        kb_config.rgb_saved_mode  = RGB_MATRIX_SOLID_COLOR;
+        rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
+        eeconfig_update_kb_datablock(&kb_config, 0, sizeof(kb_config));
+    }
+
+    keyboard_post_init_user();
 }
 
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
-    return kb_process_record_common(keycode, record);
+    // Intercept RM_TOGG: toggle fake-off flag instead of truly disabling
+    // RGB, so the indicator callback keeps firing.
+    // IMPORTANT: must block BOTH press AND release — QMK's process_rgb_matrix
+    // triggers on key release by default (not press), so letting the release
+    // through would call rgb_matrix_toggle() and truly disable the matrix.
+    if (keycode == RM_TOGG) {
+        if (record->event.pressed) {
+            kb_config.rgb_effects_off = !kb_config.rgb_effects_off;
+            if (kb_config.rgb_effects_off) {
+                // Save current mode, switch to cheapest effect to reduce
+                // CPU and DMA overhead while LEDs appear off.
+                kb_config.rgb_saved_mode = rgb_matrix_get_mode();
+                rgb_matrix_mode_noeeprom(RGB_MATRIX_SOLID_COLOR);
+            } else {
+                // Restore the user's previous effect mode.
+                rgb_matrix_mode_noeeprom(kb_config.rgb_saved_mode);
+            }
+            eeconfig_update_kb_datablock(&kb_config, 0, sizeof(kb_config));
+        }
+        return false;  // Consumed — don't pass to library or QMK
+    }
+    if (!kb_process_record_common(keycode, record)) {
+        return false;
+    }
+    return process_record_user(keycode, record);
 }

--- a/keyboards/chosfox/geonixr2/keyboard.json
+++ b/keyboards/chosfox/geonixr2/keyboard.json
@@ -98,7 +98,7 @@
             "riverflow": true
         }
     },
-    "processor": "FS026",
+    "processor": "cortex-m0",
     "bootloader": "custom",
     "layouts": {
         "LAYOUT_tkl_ansi": {

--- a/keyboards/chosfox/geonixr2/rules.mk
+++ b/keyboards/chosfox/geonixr2/rules.mk
@@ -1,3 +1,9 @@
+# Patch ChibiOS-Contrib header guard bug (copy-paste from ES32F0283 -> FS026).
+# The ifndef guard uses __SYSTEM_FS026_H__ but the define uses __SYSTEM_ES32F0283_H__,
+# so the guard never activates. This sed is idempotent — safe to run on every build.
+$(shell sed -i 's/__SYSTEM_ES32F0283_H__/__SYSTEM_FS026_H__/' \
+    lib/chibios-contrib/os/common/ext/CMSIS/ES32/FS026/system_fs026.h 2>/dev/null)
+
 # MCU configuration
 MCU_FAMILY = ES32
 MCU_SERIES = FS026

--- a/lib/rdmctmzt_common/rdmctmzt_common.c
+++ b/lib/rdmctmzt_common/rdmctmzt_common.c
@@ -524,6 +524,7 @@ void Init_Keyboard_Infomation(void) {
 #endif
     }
 
+#if HAS_MODE_SWITCH
     // Read current mode switch position and set initial mode accordingly
     Current_Mode_Switch_Position = Read_Mode_Switch_Position();
     Last_Mode_Switch_Position    = Current_Mode_Switch_Position;
@@ -544,6 +545,7 @@ void Init_Keyboard_Infomation(void) {
             }
             break;
     }
+#endif
 }
 
 void es_change_qmk_nkro_mode_enable(void) {

--- a/lib/rdmctmzt_common/rdmctmzt_common.h
+++ b/lib/rdmctmzt_common/rdmctmzt_common.h
@@ -186,6 +186,15 @@ typedef enum {
 #    define LED_CONNECTION_INDICATOR_ENABLE 0
 #endif
 
+// Physical Mode Switch
+// When enabled, the keyboard reads GPIO pins (MODE_2P4G_IO, MODE_BLE_IO) to
+// detect a physical 3-position mode switch and overrides the EEPROM-saved
+// wireless mode on boot.  Set to 0 in keyboard's config.h for boards without
+// a physical switch — the EEPROM-saved mode will be trusted directly.
+#ifndef HAS_MODE_SWITCH
+#    define HAS_MODE_SWITCH 1
+#endif
+
 #define KC_K29 KC_BACKSLASH
 #define KC_K42 KC_NONUS_HASH
 #define KC_K45 KC_NONUS_BACKSLASH

--- a/lib/rdmctmzt_common/user_system.c
+++ b/lib/rdmctmzt_common/user_system.c
@@ -117,8 +117,10 @@ void Init_Gpio_Infomation(void) {
     gpio_set_pin_input(ES_USB_POWER_IO);
 
     // Mode switch pins (from original working implementation)
+#if HAS_MODE_SWITCH
     gpio_set_pin_input_high(MODE_2P4G_IO); // 2.4G mode switch
     gpio_set_pin_input_high(MODE_BLE_IO);  // BLE mode switch
+#endif
 
     md_gpio_inittypedef gpiox;
 
@@ -405,7 +407,7 @@ void es_chibios_user_idle_loop_hook(void) {
                 }
 
                 for (uint8_t k = 0; k < MATRIX_COLS; k++) {
-                    gpio_write_pin_high(User_Pin_Tab_Col[j]);
+                    gpio_write_pin_high(User_Pin_Tab_Col[k]);
                 }
 
                 delay = 50;
@@ -448,6 +450,7 @@ void es_chibios_user_idle_loop_hook(void) {
 }
 
 // Mode switch detection implementation
+#if HAS_MODE_SWITCH
 uint8_t Read_Mode_Switch_Position(void) {
     bool mode_2p4g = gpio_read_pin(MODE_2P4G_IO); // 2.4G switch
     bool mode_ble  = gpio_read_pin(MODE_BLE_IO);  // BLE switch
@@ -578,3 +581,12 @@ void Debug_Mode_Switch_Position(void) {
     // Format: 2P4G:x BLE:x POS:x MODE:x
     printf("2P4G:%d BLE:%d POS:%d MODE:%d\n", mode_2p4g, mode_ble, position, Keyboard_Info.Key_Mode);
 }
+
+#else /* !HAS_MODE_SWITCH */
+
+/* No physical mode switch — EEPROM-saved mode is trusted directly. */
+void Check_Mode_Switch_Changed(void) {}
+void Debug_Mode_Switch_Position(void) {}
+
+#endif /* HAS_MODE_SWITCH */
+


### PR DESCRIPTION
## Summary

This PR fixes several bugs in the Geonix R2 keyboard definition and the `rdmctmzt_common` library that affect boards without a physical mode switch. Changes include both library-level fixes (benefiting all boards using the library) and Geonix R2-specific fixes.

## Changes

### 1. Wireless mode not persisting across power cycles (library)

**Problem:** `Init_Keyboard_Infomation()` reads the saved wireless mode from EEPROM, then unconditionally reads GPIO pins (`MODE_2P4G_IO`, `MODE_BLE_IO`) for a physical 3-position mode switch and overrides the EEPROM value. The Geonix R2 has no physical mode switch, so those pins float and always read as USB mode — every power cycle resets the keyboard to USB regardless of what the user selected.

**Fix:** Added a `HAS_MODE_SWITCH` preprocessor guard (defaults to `1` for backward compatibility). When set to `0` in a keyboard's `config.h`, the library skips GPIO reads, GPIO initialization, and provides no-op stubs for the mode switch functions. The EEPROM-saved mode is trusted directly. This benefits any board using `rdmctmzt_common` without a physical mode switch.

### 2. RGB indicators stop working after RM_TOGG (keyboard)

**Problem:** When the user presses `RM_TOGG` to turn off RGB backlighting, QMK sets `rgb_matrix_config.enable = false`, which causes `rgb_matrix_task()` to skip calling `rgb_matrix_indicators_advanced_kb()` entirely. The library relies on that callback for wireless mode, battery, caps lock, and win lock indicators. With RGB off, all indicators disappear.

**Fix:** Intercept `RM_TOGG` in `process_record_kb` to toggle a "fake-off" flag instead of truly disabling RGB. When active, the indicator callback blacks out all key LEDs before the library draws its indicators (LEDs appear off, indicators still work). The RGB effect is switched to `RGB_MATRIX_SOLID_COLOR` to minimize overhead. State is persisted in QMK's KB-level eeconfig datablock (1 byte) so it survives power cycles.

### 3. `_kb` callbacks not chaining to `_user` (keyboard)

**Problem:** The `_kb` callback functions delegate to the library but never call the corresponding `_user` functions, so keymap-level code (`process_record_user`, `keyboard_post_init_user`, etc.) is silently ignored.

**Fix:** All `_kb` callbacks now chain to their `_user` counterparts following QMK convention.

### 4. Wake-from-sleep key scan bug (library)

**Problem:** In `es_chibios_user_idle_loop_hook()`, the wake-up key scan loop uses variable `j` instead of `k` when resetting column pins: `gpio_write_pin_high(User_Pin_Tab_Col[j])` inside a `for (uint8_t k = ...)` loop. Only one column pin gets toggled repeatedly instead of resetting all columns.

**Fix:** `User_Pin_Tab_Col[j]` → `User_Pin_Tab_Col[k]`.

### 5. `LED_USB_INDEX` pointing to wrong key (keyboard config)

**Problem:** `LED_USB_INDEX` is set to `5` (T key), but the vendor firmware shows USB mode on LED `0` (Tab key). Other mode indicators use LEDs 0–4 (Tab/Q/W/E/R).

**Fix:** Changed `LED_USB_INDEX` from `5` to `0`.

### 6. BLE names/ID not matching vendor firmware (keyboard config)

**Problem:** BLE names (`GEONIXR2-1`) and BLE ID (`0x00A5`) don't match the vendor firmware (`Geonix rev.2-1`, `0x2052`). This causes paired devices to show different names when switching firmware and may require re-pairing.

**Fix:** Updated to match vendor firmware values.

### 7. Build fixes (keyboard)

- **`processor` field:** Changed from `"FS026"` (not recognized by QMK) to `"cortex-m0"` (the actual CPU core).
- **ChibiOS header guard:** Workaround for a copy-paste bug in `chibios-contrib` where `system_fs026.h` has mismatched `#ifndef`/`#define` guards. Added idempotent `sed` in `rules.mk`.

## Testing

Tested on a Chosfox Geonix Rev.2 (Tri-Mode). Wireless mode persists across power cycles in all modes (USB, BLE 1-3, 2.4G). RGB toggle state persists across power cycles. Indicators remain functional with RGB off.