### PR TITLE
epomaker/luma40: MIDI step sequencer keymap (+ make the sequencer build)

### DIFF
--- a/builddefs/common_features.mk
+++ b/builddefs/common_features.mk
@@ -80,7 +80,11 @@ ifeq ($(strip $(AUDIO_ENABLE)), yes)
 endif
 
 ifeq ($(strip $(SEQUENCER_ENABLE)), yes)
+    OPT_DEFS += -DSEQUENCER_ENABLE
     MUSIC_ENABLE = yes
+    COMMON_VPATH += $(QUANTUM_PATH)/sequencer
+    SRC += $(QUANTUM_DIR)/sequencer/sequencer.c
+    SRC += $(QUANTUM_DIR)/process_keycode/process_sequencer.c
 endif
 
 ifeq ($(strip $(MIDI_ENABLE)), yes)

--- a/keyboards/epomaker/luma40/keymaps/sequencer/config.h
+++ b/keyboards/epomaker/luma40/keymaps/sequencer/config.h
@@ -1,0 +1,15 @@
+// Copyright 2025 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+// A 5th layer holds the sequencer panel (the stock keymap uses 4).
+#define DYNAMIC_KEYMAP_LAYER_COUNT 5
+
+// MIDI is required by the sequencer: basic note on/off + advanced octave control.
+#define MIDI_BASIC
+#define MIDI_ADVANCED
+
+// 32-step, 6-track drum sequencer.
+#define SEQUENCER_STEPS 32
+#define SEQUENCER_TRACKS 6

--- a/keyboards/epomaker/luma40/keymaps/sequencer/keymap.c
+++ b/keyboards/epomaker/luma40/keymaps/sequencer/keymap.c
@@ -1,0 +1,43 @@
+// Copyright 2025 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+#include "rdmctmzt_common.h"
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    [0] = LAYOUT_tkl_ansi(
+        KC_TAB,  KC_Q,    KC_W,      KC_E,     KC_R,       KC_T,      KC_Y,     KC_U,    KC_I,    KC_O,     KC_P,     KC_BSPC,
+        KC_CAPS, KC_A,    KC_S,      KC_D,     KC_F,       KC_G,      KC_H,     KC_J,    KC_K,    KC_L,     KC_SCLN,  KC_ENT,
+        KC_LSFT, KC_Z,    KC_X,      KC_C,     KC_V,       KC_B,      KC_N,     KC_M,    KC_COMM, KC_DOT,   KC_UP ,   KC_QUOT,
+        MO(2),   KC_LCTL, KC_GRV,    KC_LGUI,  KC_LALT,               KC_SPC,   KC_RGUI, KC_SLSH, KC_LEFT,  KC_DOWN,  KC_RGHT
+    ),
+    [1] = LAYOUT_tkl_ansi(
+        KC_TAB,  KC_Q,    KC_W,      KC_E,     KC_R,       KC_T,      KC_Y,     KC_U,    KC_I,    KC_O,     KC_P,     KC_BSPC,
+        KC_CAPS, KC_A,    KC_S,      KC_D,     KC_F,       KC_G,      KC_H,     KC_J,    KC_K,    KC_L,     KC_SCLN,  KC_ENT,
+        KC_LSFT, KC_Z,    KC_X,      KC_C,     KC_V,       KC_B,      KC_N,     KC_M,    KC_COMM, KC_DOT,   KC_UP ,   KC_QUOT,
+        MO(3),   KC_LCTL, KC_GRV,    KC_LALT,  KC_LGUI,               KC_SPC,   KC_RALT, KC_SLSH, KC_LEFT,  KC_DOWN,  KC_RGHT
+    ),
+    [2] = LAYOUT_tkl_ansi(
+        KC_TAB,  MD_BLE1, MD_BLE2,   MD_BLE3,  MD_24G,     RM_NEXT,   TO(1),    TO(0),   KC_LBRC, KC_RBRC,  KC_BSLS,  RM_TOGG,
+        KC_ESC,  KC_1,    KC_2,      KC_3,     KC_4,       KC_5,      KC_6,     KC_7,    KC_8,    KC_9,     KC_0,     KC_MINS,
+        KC_LSFT, KC_INS,  KC_DEL,    KC_HOME,  KC_END,     KC_PGUP,   KC_PGDN,  RM_SATD, RM_HUED, RM_HUEU,  RM_VALU , QK_BAT,
+        KC_NO,   KC_DEL,  KC_GRV,    KC_LGUI,  KC_LALT,               EE_CLR,   RM_SATU, KC_EQL,  RM_SPDD,  RM_VALD,  RM_SPDU
+    ),
+    [3] = LAYOUT_tkl_ansi(
+        KC_TAB,  MD_BLE1, MD_BLE2,   MD_BLE3,  MD_24G,     RM_NEXT,   TO(1),    TO(0),   KC_LBRC, KC_RBRC,  KC_BSLS,  RM_TOGG,
+        KC_ESC,  KC_1,    KC_2,      KC_3,     KC_4,       KC_5,      KC_6,     KC_7,    KC_8,    KC_9,     KC_0,     KC_MINS,
+        KC_LSFT, KC_INS,  KC_DEL,    KC_HOME,  KC_END,     KC_PGUP,   KC_PGDN,  RM_SATD, RM_HUED, RM_HUEU,  RM_VALU , QK_BAT,
+        KC_NO,   KC_DEL,  KC_GRV,    KC_LALT,  QK_WLO,                EE_CLR,   RM_SATU, KC_EQL,  RM_SPDD,  RM_VALD,  RM_SPDU
+    ),
+    // MIDI step sequencer. Toggle this layer with the two bottom corner keys
+    // pressed together (handled in luma40.c). Two blocks of 16 steps flank a
+    // center column of 6 track selects; PLAY is the spacebar.
+    [4] = LAYOUT_tkl_ansi(
+        SQ_SALL, SQ_S(0),  SQ_S(1),   SQ_S(2),  SQ_S(3),    SQ_T(0),   SQ_T(1),  SQ_S(4),  SQ_S(5),  SQ_S(6),  SQ_S(7),  SQ_TMPU,
+        SQ_SCLR, SQ_S(8),  SQ_S(9),   SQ_S(10), SQ_S(11),   SQ_T(2),   SQ_T(3),  SQ_S(12), SQ_S(13), SQ_S(14), SQ_S(15), SQ_TMPD,
+        KC_NO,   SQ_S(16), SQ_S(17),  SQ_S(18), SQ_S(19),   SQ_T(4),   SQ_T(5),  SQ_S(20), SQ_S(21), SQ_S(22), SQ_S(23), SQ_RESU,
+        KC_NO,   SQ_S(24), SQ_S(25),  SQ_S(26), SQ_S(27),              SQ_TOGG,  SQ_S(28), SQ_S(29), SQ_S(30), SQ_S(31), SQ_RESD
+    )
+};
+// clang-format on

--- a/keyboards/epomaker/luma40/keymaps/sequencer/rules.mk
+++ b/keyboards/epomaker/luma40/keymaps/sequencer/rules.mk
@@ -1,0 +1,6 @@
+VIA_ENABLE = yes
+DYNAMIC_KEYMAP_ENABLE = yes
+
+# MIDI step sequencer (drum machine) on a dedicated layer.
+MIDI_ENABLE = yes
+SEQUENCER_ENABLE = yes

--- a/keyboards/epomaker/luma40/luma40.c
+++ b/keyboards/epomaker/luma40/luma40.c
@@ -61,10 +61,99 @@ led_config_t g_led_config = {
 // clang-format on
 
 // ============================================================================
-// QMK Callback Functions - Delegate to common implementations
+// MIDI step sequencer (layer 4) — data
+// ============================================================================
+#ifdef SEQUENCER_ENABLE
+#    define SEQUENCER_LAYER 4
+// Enter/exit combo: the two bottom corner keys, matched by physical position
+// so it works no matter what is mapped on them.
+#    define SEQ_CORNER_L_ROW 3
+#    define SEQ_CORNER_L_COL 0
+#    define SEQ_CORNER_R_ROW 3
+#    define SEQ_CORNER_R_COL 11
+
+// BPM added/removed per press of SQ_TMPU / SQ_TMPD.
+#    define SEQ_TEMPO_STEP 5
+
+// The 6 tracks send Bitwig Drum Machine's first 6 pads: C1..F1 (MIDI 36-41).
+// midi_config.octave is set to 2 in keyboard_post_init so C_1 -> 36.
+const uint16_t luma40_seq_track_notes[SEQUENCER_TRACKS] = {
+    QK_MIDI_NOTE_C_1,       // 36
+    QK_MIDI_NOTE_C_SHARP_1, // 37
+    QK_MIDI_NOTE_D_1,       // 38
+    QK_MIDI_NOTE_D_SHARP_1, // 39
+    QK_MIDI_NOTE_E_1,       // 40
+    QK_MIDI_NOTE_F_1,       // 41
+};
+
+// RGB LED index for each of the 32 steps (matches the layer-4 layout).
+const uint8_t luma40_seq_step_led[SEQUENCER_STEPS] = {
+     1,  2,  3,  4,   7,  8,  9, 10,
+    13, 14, 15, 16,  19, 20, 21, 22,
+    25, 26, 27, 28,  31, 32, 33, 34,
+    37, 38, 39, 40,  42, 43, 44, 45,
+};
+// RGB LED index for each of the 6 track-select keys, and the PLAY (space) key.
+const uint8_t luma40_seq_track_led[SEQUENCER_TRACKS] = {5, 6, 17, 18, 29, 30};
+#    define SEQ_PLAY_LED 41
+// Left + right edge columns ("side bars"): a fixed color instead of the rainbow.
+const uint8_t luma40_seq_bar_led[8] = {0, 12, 24, 36, 11, 23, 35, 46};
+
+static bool seq_corner_l = false;
+static bool seq_corner_r = false;
+#endif
+
+// ============================================================================
+// QMK Callback Functions
 // ============================================================================
 
 bool rgb_matrix_indicators_advanced_user(uint8_t led_min, uint8_t led_max) {
+#ifdef SEQUENCER_ENABLE
+    if (get_highest_layer(layer_state) == SEQUENCER_LAYER) {
+        // Which track is selected (first active track); -1 = none.
+        int8_t sel = -1;
+        for (uint8_t t = 0; t < SEQUENCER_TRACKS; t++) {
+            if (is_sequencer_track_active(t)) { sel = t; break; }
+        }
+        // Steps: soft teal — empty dim, active mid; playhead = warm amber (contrast).
+        for (uint8_t s = 0; s < SEQUENCER_STEPS; s++) {
+            uint8_t led = luma40_seq_step_led[s];
+            if (led < led_min || led >= led_max) continue;
+            if (is_sequencer_on() && sequencer_get_current_step() == s) {
+                rgb_matrix_set_color(led, 210, 125, 25); // playhead: amber
+            } else if (is_sequencer_step_on(s)) {
+                rgb_matrix_set_color(led, 34, 110, 118);  // active step: teal
+            } else {
+                rgb_matrix_set_color(led, 6, 16, 18);     // empty step: dim teal
+            }
+        }
+        // Track-select keys: soft blue — dim (idle), bright (selected).
+        for (uint8_t t = 0; t < SEQUENCER_TRACKS; t++) {
+            uint8_t led = luma40_seq_track_led[t];
+            if (led < led_min || led >= led_max) continue;
+            if (t == sel) {
+                rgb_matrix_set_color(led, 90, 140, 255); // selected
+            } else {
+                rgb_matrix_set_color(led, 22, 32, 72);   // idle
+            }
+        }
+        // PLAY (space): same blue as the selector but lower — dim (stopped) / mid (playing).
+        if (SEQ_PLAY_LED >= led_min && SEQ_PLAY_LED < led_max) {
+            if (is_sequencer_on()) {
+                rgb_matrix_set_color(SEQ_PLAY_LED, 55, 90, 175);
+            } else {
+                rgb_matrix_set_color(SEQ_PLAY_LED, 16, 24, 52);
+            }
+        }
+        // Side bars (left + right edge columns): fixed soft purple, no rainbow.
+        for (uint8_t i = 0; i < 8; i++) {
+            uint8_t led = luma40_seq_bar_led[i];
+            if (led < led_min || led >= led_max) continue;
+            rgb_matrix_set_color(led, 50, 22, 80);
+        }
+        return false;
+    }
+#endif
     return kb_rgb_matrix_indicators_common(led_min, led_max);
 }
 
@@ -86,8 +175,39 @@ void board_init(void) {
 
 void keyboard_post_init_user(void) {
     kb_keyboard_post_init();
+#ifdef SEQUENCER_ENABLE
+    sequencer_set_track_notes(luma40_seq_track_notes);
+    midi_config.octave = 2; // map track notes C_1..F_1 to MIDI 36..41 (Bitwig C1..F1)
+#endif
 }
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+#ifdef SEQUENCER_ENABLE
+    if (record->event.key.row == SEQ_CORNER_L_ROW && record->event.key.col == SEQ_CORNER_L_COL) {
+        seq_corner_l = record->event.pressed;
+    }
+    if (record->event.key.row == SEQ_CORNER_R_ROW && record->event.key.col == SEQ_CORNER_R_COL) {
+        seq_corner_r = record->event.pressed;
+    }
+    if (seq_corner_l && seq_corner_r) {
+        seq_corner_l = false;
+        seq_corner_r = false;
+        layer_invert(SEQUENCER_LAYER);
+        return false;
+    }
+    // Bigger tempo jumps: SQ_TMPU / SQ_TMPD move by SEQ_TEMPO_STEP BPM per press.
+    if (record->event.pressed) {
+        if (keycode == QK_SEQUENCER_TEMPO_UP) {
+            uint8_t t = sequencer_get_tempo();
+            sequencer_set_tempo(t > 255 - SEQ_TEMPO_STEP ? 255 : t + SEQ_TEMPO_STEP);
+            return false;
+        }
+        if (keycode == QK_SEQUENCER_TEMPO_DOWN) {
+            uint8_t t = sequencer_get_tempo();
+            sequencer_set_tempo(t <= SEQ_TEMPO_STEP ? 1 : t - SEQ_TEMPO_STEP);
+            return false;
+        }
+    }
+#endif
     return kb_process_record_common(keycode, record);
 }

--- a/quantum/process_keycode/process_sequencer.c
+++ b/quantum/process_keycode/process_sequencer.c
@@ -15,6 +15,8 @@
  */
 
 #include "process_sequencer.h"
+#include "quantum_keycodes.h"
+#include "sequencer.h"
 
 bool process_sequencer(uint16_t keycode, keyrecord_t *record) {
     if (record->event.pressed) {


### PR DESCRIPTION
## What this adds

A `sequencer` keymap for the Epomaker Luma40 that turns a dedicated layer into a **32-step, 6-track MIDI drum sequencer**, using QMK's built-in (but currently un-buildable) MIDI sequencer feature.

Built and flashed on real hardware (macOS host, ES32FS026), tested sending MIDI into Bitwig. 🥁

### Two commits

**1. Make the sequencer feature build again** (generic, not Luma40-specific)

`SEQUENCER_ENABLE` only set `MUSIC_ENABLE`, so `-DSEQUENCER_ENABLE` was never defined and neither `sequencer.c` nor `process_sequencer.c` were added to `SRC`; `process_sequencer.c` was also missing the includes it depends on. This wires the target up like the other feature blocks in `common_features.mk` and adds the includes.

**2. epomaker/luma40: add a MIDI step sequencer keymap**

A dedicated layer becomes the sequencer panel:
- 32 step toggles in two blocks flanking a center column of 6 track-selects; **spacebar = play/stop**.
- Enter/exit by pressing the **two bottom-corner keys together** — matched by matrix position, so it works regardless of remapping.
- **RGB feedback**: active steps (teal), playhead (amber), selected track (blue), transport state, fixed purple side bars.
- Track notes map to Bitwig's first six drum pads (**C1..F1 / MIDI 36..41**).
- `MIDI_ENABLE` / `SEQUENCER_ENABLE` live in the keymap, so the stock `default` keymap is untouched and still builds.

Thanks for maintaining these Epomaker ports — this was a fun one to build on. 🙏
