### PR TITLE
Epomaker Split70

### DIFF
--- a/keyboards/epomaker/split70/VIAMapping-Epomaker_Split70.json
+++ b/keyboards/epomaker/split70/VIAMapping-Epomaker_Split70.json
@@ -1,0 +1,293 @@
+{
+  "name": "Epomaker_Split70",
+  "vendorId": "0x342d",
+  "productId": "0xe491",
+  "keycodes": ["qmk_lighting"],
+  "menus": [
+    {
+      "label": "Lighting",
+      "content": [
+        {
+          "label": "Backlight",
+          "content": [
+            {
+              "label": "Brightness",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_brightness", 3, 1]
+            },
+            {
+                "label": "Effect",
+                "type": "dropdown",
+                "content": ["id_qmk_rgb_matrix_effect", 3, 2],
+                "options": [
+                    ["none", 0],
+                    ["solid_color", 1],
+                    ["alphas_mods", 2],
+                    ["gradient_up_down", 3],
+                    ["gradient_left_right", 4],
+                    ["breathing", 5],
+                    ["band_sat", 6],
+                    ["band_val", 7],
+                    ["band_pinwheel_sat", 8],
+                    ["band_pinwheel_val", 9],
+                    ["band_spiral_sat", 10],
+                    ["band_spiral_val", 11],
+                    ["cycle_all", 12],
+                    ["cycle_left_right", 13],
+                    ["cycle_up_down", 14],
+                    ["cycle_out_in", 15],
+                    ["cycle_out_in_dual", 16],
+                    ["rainbow_moving_chevron", 17],
+                    ["cycle_pinwheel", 18],
+                    ["cycle_spiral", 19],
+                    ["dual_beacon", 20],
+                    ["rainbow_beacon", 21],
+                    ["rainbow_pinwheels", 22],
+                    ["flower_blooming", 23],
+                    ["raindrops", 24],
+                    ["jellybean_raindrops", 25],
+                    ["hue_breathing", 26],
+                    ["hue_pendulum", 27],
+                    ["hue_wave", 28],
+                    ["pixel_fractal", 29],
+                    ["pixel_flow", 30],
+                    ["pixel_rain", 31],
+                    ["typing_heatmap", 32],
+                    ["digital_rain", 33],
+                    ["solid_reactive", 34],
+                    ["solid_reactive_wide", 35],
+                    ["solid_reactive_multiwide", 36],
+                    ["solid_reactive_cross", 37],
+                    ["solid_reactive_multicross", 38],
+                    ["solid_reactive_nexus", 39],
+                    ["solid_reactive_multinexus", 40],
+                    ["splash", 41],
+                    ["multisplash", 42],
+                    ["solid_splash", 43],
+                    ["solid_multisplash", 44],
+                    ["starlight", 45],
+                    ["starlight_smooth", 46],
+                    ["starlight_dual_hue", 47],
+                    ["starlight_dual_sat", 48],
+                    ["riverflow", 49]
+                ]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0",
+              "label": "Effect Speed",
+              "type": "range",
+              "options": [0, 255],
+              "content": ["id_qmk_rgb_matrix_effect_speed", 3, 3]
+            },
+            {
+              "showIf": "{id_qmk_rgb_matrix_effect} != 0 && {id_qmk_rgb_matrix_effect} != 24 && {id_qmk_rgb_matrix_effect} != 28 && {id_qmk_rgb_matrix_effect} != 29 && {id_qmk_rgb_matrix_effect} != 32",
+              "label": "Color",
+              "type": "color",
+              "content": ["id_qmk_rgb_matrix_color", 3, 4]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "matrix": {"rows": 10, "cols": 9},
+  "customKeycodes": [
+    {"name": "IM_BATQ", "title": "IM_BATQ",  "shortName": "IM_BATQ"},
+    {"name": "KC_FILP", "title": "KC_FILP",  "shortName": "KC_FILP"},
+    {"name": "MM_BATQ", "title": "MM_BATQ",  "shortName": "MM_BATQ"},
+    {"name": "MOR_1", "title": "MOR_1",  "shortName": "MOR_1"},
+    {"name": "MOR_2", "title": "MOR_2",  "shortName": "MOR_2"},
+    {"name": "MOR_3", "title": "MOR_3",  "shortName": "MOR_3"},
+    {"name": "MOR_4", "title": "MOR_4",  "shortName": "MOR_4"},
+    {"name": "RL_MOD", "title": "RL_MOD",  "shortName": "RL_MOD"}
+  ],
+  "layouts": {
+      "keymap":
+        [
+          [
+            {
+              "c": "#777777"
+            },
+            "0,0\n\n\n\n\n\n\n\n\ne0",
+            {
+              "x": 0.25,
+              "c": "#cccccc"
+            },
+            "0,1",
+            "0,2",
+            "0,3",
+            "0,4",
+            "0,5",
+            "0,6",
+            "0,7",
+            {
+              "x": 0.5
+            },
+            "5,1",
+            "5,2",
+            "5,3",
+            "5,4",
+            "5,5",
+            "5,6",
+            "5,7",
+            {
+              "c": "#aaaaaa",
+              "w": 2
+            },
+            "5,8"
+          ],
+          [
+            {
+              "c": "#cccccc"
+            },
+            "1,0",
+            {
+              "x": 0.25,
+              "c": "#aaaaaa",
+              "w": 1.5
+            },
+            "1,1",
+            {
+              "c": "#cccccc"
+            },
+            "1,2",
+            "1,3",
+            "1,4",
+            "1,5",
+            "1,6",
+            {
+              "x": 1.5
+            },
+            "6,1",
+            "6,2",
+            "6,3",
+            "6,4",
+            "6,5",
+            "6,6",
+            "6,7",
+            {
+              "w": 1.5
+            },
+            "6,8"
+          ],
+          [
+            "2,0",
+            {
+              "x": 0.25,
+              "c": "#aaaaaa",
+              "w": 1.75
+            },
+            "2,1",
+            {
+              "c": "#cccccc"
+            },
+            "2,2",
+            "2,3",
+            "2,4",
+            "2,5",
+            "2,6",
+            {
+              "x": 1.5
+            },
+            "7,1",
+            "7,2",
+            "7,3",
+            "7,4",
+            "7,5",
+            {
+              "c": "#777777"
+            },
+            "7,6",
+            {
+              "c": "#cccccc",
+              "w": 2.25
+            },
+            "7,7"
+          ],
+          [
+            "3,0",
+            {
+              "x": 0.25,
+              "c": "#aaaaaa",
+              "w": 2.25
+            },
+            "3,1",
+            {
+              "c": "#cccccc"
+            },
+            "3,2",
+            "3,3",
+            "3,4",
+            "3,5",
+            "3,6",
+            {
+              "x": 0.25
+            },
+            "8,0",
+            "8,1",
+            "8,2",
+            "8,3",
+            "8,4",
+            {
+              "c": "#aaaaaa"
+            },
+            "8,5",
+            {
+              "c": "#cccccc"
+            },
+            "8,6",
+            "8,7",
+            "8,8"
+          ],
+          [
+            {
+              "c": "#aaaaaa"
+            },
+            "4,0",
+            {
+              "x": 0.25,
+              "w": 1.25
+            },
+            "4,1",
+            {
+              "w": 1.25
+            },
+            "4,2",
+            {
+              "w": 1.25
+            },
+            "4,3",
+            {
+              "x": 0.25,
+              "w": 3
+            },
+            "4,5",
+            {
+              "x": 0.75,
+              "c": "#cccccc",
+              "w": 2.75
+            },
+            "9,1",
+            {
+              "c": "#aaaaaa",
+              "w": 1.25
+            },
+            "9,3",
+            {
+              "w": 1.25
+            },
+            "9,4",
+            {
+              "x": 0.5
+            },
+            "9,6",
+            "9,7",
+            {
+              "c": "#cccccc"
+            },
+            "9,8"
+          ]
+        ]
+  }
+}

--- a/keyboards/epomaker/split70/config.h
+++ b/keyboards/epomaker/split70/config.h
@@ -1,0 +1,103 @@
+// Copyright 2024 Epomaker (@Epomaker)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#define USB_POWER_EN_PIN                    B1 // USB ENABLE pin
+#define LED_POWER_EN_PIN                    A5 // LED ENABLE pin
+#define LED_POWER_EN2_PIN                    A8 // LED ENABLE pin
+#define HS_BAT_CABLE_PIN                    A7 // USB insertion detection pin
+
+#define BAT_FULL_PIN                        A15
+#define BAT_FULL_STATE                      1
+
+#define MATRIX_ROWS                         10
+#define MATRIX_COLS                         9
+
+#define HS_RGB_INDICATOR_COUNT              99
+#define HS_RGB_BAT_COUNT                    1
+
+#define MD_BT1_NAME                         "Split70-1"
+#define MD_BT2_NAME                         "Split70-2"
+#define MD_BT3_NAME                         "Split70-3"
+#define MD_DONGLE_PRODUCT                   "Epomaker Split70"
+
+/* Device Connection RGB Indicator Light Index And Color */
+#define HS_RGB_BLINK_INDEX_BT1              14
+#define HS_RGB_BLINK_INDEX_BT2              13
+#define HS_RGB_BLINK_INDEX_BT3              12
+#define HS_RGB_BLINK_INDEX_2G4              11
+
+#define HS_LBACK_COLOR_BT1                  RGB_BLUE
+#define HS_LBACK_COLOR_BT2                  RGB_BLUE
+#define HS_LBACK_COLOR_BT3                  RGB_BLUE
+#define HS_LBACK_COLOR_2G4                  RGB_GREEN
+#define HS_LBACK_COLOR_USB                  RGB_WHITE
+
+#define HS_PAIR_COLOR_BT1                   RGB_BLUE
+#define HS_PAIR_COLOR_BT2                   RGB_BLUE
+#define HS_PAIR_COLOR_BT3                   RGB_BLUE
+#define HS_PAIR_COLOR_2G4                   RGB_GREEN
+#define HS_PAIR_COLOR_USB                   RGB_WHITE
+
+/* Battery */
+#define BATTERY_CAPACITY_LOW                15
+#define BATTERY_CAPACITY_STOP               0
+#define RGB_MATRIX_BAT_INDEX_MAP            {5, 6, 7, 8, 9, 39, 40, 41, 42, 43}
+
+/* Status Indicator Lamp */
+#define HS_MATRIX_BLINK_INDEX_BAT           33
+#define HS_RGB_INDEX_CAPS                   18
+#define HS_RGB_INDEX_WIN_LOCK               73
+
+#define HS_RGB_BLINK_INDEX_WIN              19
+#define HS_RGB_BLINK_INDEX_MAC              20
+
+/* UART */
+#define SERIAL_DRIVER                       SD3
+#define SD1_TX_PIN                          C10
+#define SD1_RX_PIN                          C11
+#define UART_DRIVER                         SD3
+#define UART_TX_PIN                         C10
+#define UART_RX_PIN                         C11
+#define UART_TX_PAL_MODE                    7
+#define UART_RX_PAL_MODE                    7
+
+/* Encoder */
+#define ENCODER_MAP_KEY_DELAY               1
+
+/* SPI */
+#define SPI_DRIVER                          SPIDQ
+#define SPI_SCK_PIN                         B3
+#define SPI_MOSI_PIN                        B5
+#define SPI_MISO_PIN                        B4
+
+/* Flash */
+#define EXTERNAL_FLASH_SPI_SLAVE_SELECT_PIN C12
+#define WEAR_LEVELING_LOGICAL_SIZE          (WEAR_LEVELING_BACKING_SIZE / 2)
+
+/* RGB Matrix */
+#define RGB_MATRIX_FRAMEBUFFER_EFFECTS
+#define RGB_MATRIX_KEYPRESSES
+
+/* WS2812 */
+#define WS2812_SPI_DRIVER  SPIDM2
+#define WS2812_SPI_DIVISOR 32
+
+/*serial usart config for split communication*/
+#define SERIAL_USART_DRIVER SD1
+#define SERIAL_USART_TX_PIN A9
+#define SERIAL_USART_RX_PIN A10
+#define SERIAL_USART_TX_PAL_MODE 7
+#define SERIAL_USART_RX_PAL_MODE 7
+#define SERIAL_USART_CONFIG {115200, 3, 0, 0, 0};
+#define SPLIT_TRANSACTION_IDS_USER USER_SYNC_MMS
+#define SPLIT_HAND_PIN B9
+/* rgb_record */
+#define ENABLE_RGB_MATRIX_RGBR_PLAY
+#define RGBREC_CHANNEL_NUM         4
+#define EECONFIG_CONFINFO_USE_SIZE (4 + 16)
+#define EECONFIG_RGBREC_USE_SIZE   (RGBREC_CHANNEL_NUM * MATRIX_ROWS * MATRIX_COLS * 2)
+#define EECONFIG_USER_DATA_SIZE    (EECONFIG_RGBREC_USE_SIZE + EECONFIG_CONFINFO_USE_SIZE)
+#define RGBREC_EECONFIG_OFFSET     0
+#define CONFINFO_EECONFIG_OFFSET   (RGBREC_EECONFIG_OFFSET + (uint32_t)EECONFIG_RGBREC_USE_SIZE)

--- a/keyboards/epomaker/split70/halconf.h
+++ b/keyboards/epomaker/split70/halconf.h
@@ -1,0 +1,10 @@
+// Copyright 2024 Epomaker (@Epomaker)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#define HAL_USE_SERIAL    TRUE
+#define HAL_USE_SPI       TRUE
+#define PAL_USE_CALLBACKS TRUE
+
+#include_next <halconf.h>

--- a/keyboards/epomaker/split70/keyboard.json
+++ b/keyboards/epomaker/split70/keyboard.json
@@ -1,1505 +1,1027 @@
 {
-  "manufacturer": "Epomaker",
-  "keyboard_name": "Epomaker Split70",
-  "maintainer": "Epomaker",
-  "bootloader": "wb32-dfu",
-  "bootmagic": {
-    "matrix": [
-      0,
-      0
-    ]
-  },
-  "debounce": 1,
-  "diode_direction": "ROW2COL",
-  "dynamic_keymap": {
-    "layer_count": 4
-  },
-  "eeprom": {
-    "driver": "wear_leveling",
-    "wear_leveling": {
-      "backing_size": 4096,
-      "driver": "spi_flash"
-    }
-  },
-  "encoder": {
-    "rotary": [
-      {
-        "pin_a": "B7",
-        "pin_b": "B6"
-      }
-    ]
-  },
-  "features": {
-    "command": false,
-    "console": false,
-    "deferred_exec": true,
-    "encoder": true,
-    "extrakey": true,
-    "mousekey": true,
-    "nkro": true,
-    "rgb_matrix": true,
-      "rgblight": false
-  },
-  "keycodes": [
-    {
-      "key": "KC_BT1"
-    },
-    {
-      "key": "KC_BT2"
-    },
-    {
-      "key": "KC_BT3"
-    },
-    {
-      "key": "KC_2G4"
-    },
-    {
-      "key": "RL_MOD"
-    },
-    {
-      "key": "HS_BATQ"
-    },
-    {
-      "key": "KC_FILP"
-    },
-    {
-      "key": "KC_BATQ"
-    }
-  ],
-  "matrix_pins": {
-    "cols": [
-      "C0",
-      "C1",
-      "C2",
-      "C3",
-      "A6",
-      "B10",
-      "B11",
-      "B12",
-      null
-    ],
-    "rows": [
-      "A1",
-      "A2",
-      "A3",
-      "A4",
-      "C13"
-    ]
-  },
-  "processor": "WB32FQ95",
-  "rgb_matrix": {
-    "animations": {
-      "solid_color": true,
-      "alphas_mods": true,
-      "gradient_up_down": true,
-      "gradient_left_right": true,
-      "breathing": true,
-      "band_sat": true,
-      "band_val": true,
-      "band_pinwheel_sat": true,
-      "band_pinwheel_val": true,
-      "band_spiral_sat": true,
-      "band_spiral_val": true,
-      "cycle_all": true,
-      "cycle_left_right": true,
-      "cycle_up_down": true,
-      "cycle_out_in": true,
-      "cycle_out_in_dual": true,
-      "rainbow_moving_chevron": true,
-      "cycle_pinwheel": true,
-      "cycle_spiral": true,
-      "dual_beacon": true,
-      "rainbow_beacon": true,
-      "rainbow_pinwheels": true,
-      "flower_blooming": true,
-      "raindrops": true,
-      "jellybean_raindrops": true,
-      "hue_breathing": true,
-      "hue_pendulum": true,
-      "hue_wave": true,
-      "pixel_fractal": true,
-      "pixel_flow": true,
-      "pixel_rain": true,
-      "typing_heatmap": true,
-      "digital_rain": true,
-      "solid_reactive_simple": true,
-      "solid_reactive": true,
-      "solid_reactive_wide": true,
-      "solid_reactive_multiwide": true,
-      "solid_reactive_cross": true,
-      "solid_reactive_multicross": true,
-      "solid_reactive_nexus": true,
-      "solid_reactive_multinexus": true,
-      "splash": true,
-      "multisplash": true,
-      "solid_splash": true,
-      "solid_multisplash": true,
-      "starlight": true,
-      "starlight_smooth": true,
-      "starlight_dual_hue": true,
-      "starlight_dual_sat": true,
-      "riverflow": true
-    },
-    "default": {
-      "animation": "cycle_left_right",
-      "speed": 204,
-      "val": 80
-    },
-    "driver": "ws2812",
-    "layout": [
-      {
-        "matrix": [
-          0,
-          0
-        ],
-        "x": 0,
-        "y": 0,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          0,
-          0
-        ],
-        "x": 0,
-        "y": 0,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          0,
-          0
-        ],
-        "x": 0,
-        "y": 0,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          0,
-          1
-        ],
-        "x": 0,
-        "y": 14,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          0,
-          2
-        ],
-        "x": 0,
-        "y": 28,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          0,
-          3
-        ],
-        "x": 0,
-        "y": 42,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          0,
-          4
-        ],
-        "x": 0,
-        "y": 56,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          0,
-          5
-        ],
-        "x": 0,
-        "y": 70,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          0,
-          6
-        ],
-        "x": 0,
-        "y": 84,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          0,
-          7
-        ],
-        "x": 0,
-        "y": 98,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          1,
-          6
-        ],
-        "x": 16,
-        "y": 84,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          1,
-          5
-        ],
-        "x": 16,
-        "y": 70,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          1,
-          4
-        ],
-        "x": 16,
-        "y": 56,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          1,
-          3
-        ],
-        "x": 16,
-        "y": 42,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          1,
-          2
-        ],
-        "x": 16,
-        "y": 28,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          1,
-          1
-        ],
-        "x": 16,
-        "y": 14,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          1,
-          0
-        ],
-        "x": 16,
-        "y": 0,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          2,
-          0
-        ],
-        "x": 32,
-        "y": 0,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          2,
-          1
-        ],
-        "x": 32,
-        "y": 14,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          2,
-          2
-        ],
-        "x": 32,
-        "y": 28,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          2,
-          3
-        ],
-        "x": 32,
-        "y": 42,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          2,
-          4
-        ],
-        "x": 32,
-        "y": 56,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          2,
-          5
-        ],
-        "x": 32,
-        "y": 70,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          2,
-          6
-        ],
-        "x": 32,
-        "y": 84,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          3,
-          6
-        ],
-        "x": 48,
-        "y": 84,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          3,
-          5
-        ],
-        "x": 48,
-        "y": 70,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          3,
-          4
-        ],
-        "x": 48,
-        "y": 56,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          3,
-          3
-        ],
-        "x": 48,
-        "y": 42,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          3,
-          2
-        ],
-        "x": 48,
-        "y": 28,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          3,
-          1
-        ],
-        "x": 48,
-        "y": 14,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          3,
-          0
-        ],
-        "x": 48,
-        "y": 0,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          4,
-          0
-        ],
-        "x": 64,
-        "y": 0,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          4,
-          1
-        ],
-        "x": 64,
-        "y": 14,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          4,
-          2
-        ],
-        "x": 64,
-        "y": 28,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          4,
-          3
-        ],
-        "x": 64,
-        "y": 42,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          4,
-          5
-        ],
-        "x": 64,
-        "y": 70,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          0,
-          0
-        ],
-        "x": 0,
-        "y": 0,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          0,
-          0
-        ],
-        "x": 0,
-        "y": 0,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          0,
-          0
-        ],
-        "x": 0,
-        "y": 0,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          5,
-          1
-        ],
-        "x": 0,
-        "y": 126,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          5,
-          2
-        ],
-        "x": 0,
-        "y": 140,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          5,
-          3
-        ],
-        "x": 0,
-        "y": 154,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          5,
-          4
-        ],
-        "x": 0,
-        "y": 168,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          5,
-          5
-        ],
-        "x": 0,
-        "y": 182,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          5,
-          6
-        ],
-        "x": 0,
-        "y": 196,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          5,
-          7
-        ],
-        "x": 0,
-        "y": 210,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          5,
-          8
-        ],
-        "x": 0,
-        "y": 224,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          6,
-          8
-        ],
-        "x": 16,
-        "y": 224,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          6,
-          7
-        ],
-        "x": 16,
-        "y": 210,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          6,
-          6
-        ],
-        "x": 16,
-        "y": 196,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          6,
-          5
-        ],
-        "x": 16,
-        "y": 182,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          6,
-          4
-        ],
-        "x": 16,
-        "y": 168,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          6,
-          3
-        ],
-        "x": 16,
-        "y": 154,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          6,
-          2
-        ],
-        "x": 16,
-        "y": 140,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          6,
-          1
-        ],
-        "x": 16,
-        "y": 126,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          7,
-          1
-        ],
-        "x": 32,
-        "y": 126,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          7,
-          2
-        ],
-        "x": 32,
-        "y": 140,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          7,
-          3
-        ],
-        "x": 32,
-        "y": 154,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          7,
-          4
-        ],
-        "x": 32,
-        "y": 168,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          7,
-          5
-        ],
-        "x": 32,
-        "y": 182,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          7,
-          6
-        ],
-        "x": 32,
-        "y": 196,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          7,
-          7
-        ],
-        "x": 32,
-        "y": 210,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          8,
-          8
-        ],
-        "x": 48,
-        "y": 224,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          8,
-          7
-        ],
-        "x": 48,
-        "y": 210,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          8,
-          6
-        ],
-        "x": 48,
-        "y": 196,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          8,
-          5
-        ],
-        "x": 48,
-        "y": 182,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          8,
-          4
-        ],
-        "x": 48,
-        "y": 168,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          8,
-          3
-        ],
-        "x": 48,
-        "y": 154,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          8,
-          2
-        ],
-        "x": 48,
-        "y": 140,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          8,
-          1
-        ],
-        "x": 48,
-        "y": 126,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          8,
-          0
-        ],
-        "x": 48,
-        "y": 112,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          9,
-          1
-        ],
-        "x": 64,
-        "y": 126,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          9,
-          3
-        ],
-        "x": 64,
-        "y": 154,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          9,
-          4
-        ],
-        "x": 64,
-        "y": 168,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          9,
-          6
-        ],
-        "x": 64,
-        "y": 196,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          9,
-          7
-        ],
-        "x": 64,
-        "y": 210,
-        "flags": 4
-      },
-      {
-        "matrix": [
-          9,
-          8
-        ],
-        "x": 64,
-        "y": 224,
-        "flags": 4
-      }
-    ],
-    "max_brightness": 80,
-    "sleep": true,
-    "speed_steps": 51,
-    "val_steps": 16,
-    "split_count": [
-      36,
-      41
-    ]
-  },
-  "split": {
-    "enabled": true,
-    "transport": {
-      "sync": {
-        "activity": true,
-        "detected_os": true,
-        "layer_state": true,
-        "indicators": true,
-        "matrix_state": true,
-        "modifiers": true
-      }
-    },
-    "matrix_pins": {
-      "right": {
-        "cols": [
-          "B13",
-          "B14",
-          "C6",
-          "C7",
-          "C8",
-          "C9",
-          "C4",
-          "C5",
-          "B0"
-        ],
-        "rows": [
-          "A1",
-          "A2",
-          "A3",
-          "A4",
-          "C13"
-        ]
-      }
-    },
-    "serial": {
-      "driver": "usart"
-    },
+    "manufacturer": "Epomaker",
+    "keyboard_name": "Epomaker Split70",
+    "maintainer": "Epomaker",
+    "bootloader": "wb32-dfu",
     "bootmagic": {
-      "matrix": [
-        5,
-        1
-      ]
-    }
-  },
-  "tap_keycode_delay": 10,
-  "url": "https://epomaker.com/products/epomaker-split-70",
-  "usb": {
-    "device_version": "0.3.0",
-    "force_nkro": true,
-    "pid": "0xE491",
-    "suspend_wakeup_delay": 1000,
-    "vid": "0x342D"
-  },
-  "ws2812": {
-    "driver": "spi",
-    "pin": "B15"
-  },
-  "layouts": {
-    "LAYOUT": {
-      "layout": [
-        {
-          "matrix": [
-            0,
-            0
-          ],
-          "x": 0,
-          "y": 0
-        },
-        {
-          "matrix": [
-            0,
-            1
-          ],
-          "x": 1.25,
-          "y": 0
-        },
-        {
-          "matrix": [
-            0,
-            2
-          ],
-          "x": 2.25,
-          "y": 0
-        },
-        {
-          "matrix": [
-            0,
-            3
-          ],
-          "x": 3.25,
-          "y": 0
-        },
-        {
-          "matrix": [
-            0,
-            4
-          ],
-          "x": 4.25,
-          "y": 0
-        },
-        {
-          "matrix": [
-            0,
-            5
-          ],
-          "x": 5.25,
-          "y": 0
-        },
-        {
-          "matrix": [
-            0,
-            6
-          ],
-          "x": 6.25,
-          "y": 0
-        },
-        {
-          "matrix": [
-            0,
-            7
-          ],
-          "x": 7.25,
-          "y": 0
-        },
-        {
-          "matrix": [
-            5,
-            1
-          ],
-          "x": 8.75,
-          "y": 0
-        },
-        {
-          "matrix": [
-            5,
-            2
-          ],
-          "x": 9.75,
-          "y": 0
-        },
-        {
-          "matrix": [
-            5,
-            3
-          ],
-          "x": 10.75,
-          "y": 0
-        },
-        {
-          "matrix": [
-            5,
-            4
-          ],
-          "x": 11.75,
-          "y": 0
-        },
-        {
-          "matrix": [
-            5,
-            5
-          ],
-          "x": 12.75,
-          "y": 0
-        },
-        {
-          "matrix": [
-            5,
-            6
-          ],
-          "x": 13.75,
-          "y": 0
-        },
-        {
-          "matrix": [
-            5,
-            7
-          ],
-          "x": 14.75,
-          "y": 0
-        },
-        {
-          "matrix": [
-            5,
-            8
-          ],
-          "x": 15.75,
-          "y": 0,
-          "w": 2
-        },
-        {
-          "matrix": [
-            1,
-            0
-          ],
-          "x": 0,
-          "y": 1
-        },
-        {
-          "matrix": [
-            1,
-            1
-          ],
-          "x": 1.25,
-          "y": 1,
-          "w": 1.5
-        },
-        {
-          "matrix": [
-            1,
-            2
-          ],
-          "x": 2.75,
-          "y": 1
-        },
-        {
-          "matrix": [
-            1,
-            3
-          ],
-          "x": 3.75,
-          "y": 1
-        },
-        {
-          "matrix": [
-            1,
-            4
-          ],
-          "x": 4.75,
-          "y": 1
-        },
-        {
-          "matrix": [
-            1,
-            5
-          ],
-          "x": 5.75,
-          "y": 1
-        },
-        {
-          "matrix": [
-            1,
-            6
-          ],
-          "x": 6.75,
-          "y": 1
-        },
-        {
-          "matrix": [
-            6,
-            1
-          ],
-          "x": 9.25,
-          "y": 1
-        },
-        {
-          "matrix": [
-            6,
-            2
-          ],
-          "x": 10.25,
-          "y": 1
-        },
-        {
-          "matrix": [
-            6,
-            3
-          ],
-          "x": 11.25,
-          "y": 1
-        },
-        {
-          "matrix": [
-            6,
-            4
-          ],
-          "x": 12.25,
-          "y": 1
-        },
-        {
-          "matrix": [
-            6,
-            5
-          ],
-          "x": 13.25,
-          "y": 1
-        },
-        {
-          "matrix": [
-            6,
-            6
-          ],
-          "x": 14.25,
-          "y": 1
-        },
-        {
-          "matrix": [
-            6,
-            7
-          ],
-          "x": 15.25,
-          "y": 1
-        },
-        {
-          "matrix": [
-            6,
-            8
-          ],
-          "x": 16.25,
-          "y": 1,
-          "w": 1.5
-        },
-        {
-          "matrix": [
-            2,
-            0
-          ],
-          "x": 0,
-          "y": 2
-        },
-        {
-          "matrix": [
-            2,
-            1
-          ],
-          "x": 1.25,
-          "y": 2,
-          "w": 1.75
-        },
-        {
-          "matrix": [
-            2,
-            2
-          ],
-          "x": 3,
-          "y": 2
-        },
-        {
-          "matrix": [
-            2,
-            3
-          ],
-          "x": 4,
-          "y": 2
-        },
-        {
-          "matrix": [
-            2,
-            4
-          ],
-          "x": 5,
-          "y": 2
-        },
-        {
-          "matrix": [
-            2,
-            5
-          ],
-          "x": 6,
-          "y": 2
-        },
-        {
-          "matrix": [
-            2,
-            6
-          ],
-          "x": 7,
-          "y": 2
-        },
-        {
-          "matrix": [
-            7,
-            1
-          ],
-          "x": 9.5,
-          "y": 2
-        },
-        {
-          "matrix": [
-            7,
-            2
-          ],
-          "x": 10.5,
-          "y": 2
-        },
-        {
-          "matrix": [
-            7,
-            3
-          ],
-          "x": 11.5,
-          "y": 2
-        },
-        {
-          "matrix": [
-            7,
-            4
-          ],
-          "x": 12.5,
-          "y": 2
-        },
-        {
-          "matrix": [
-            7,
-            5
-          ],
-          "x": 13.5,
-          "y": 2
-        },
-        {
-          "matrix": [
-            7,
-            6
-          ],
-          "x": 14.5,
-          "y": 2
-        },
-        {
-          "matrix": [
-            7,
-            7
-          ],
-          "x": 15.5,
-          "y": 2,
-          "w": 2.25
-        },
-        {
-          "matrix": [
-            3,
-            0
-          ],
-          "x": 0,
-          "y": 3
-        },
-        {
-          "matrix": [
-            3,
-            1
-          ],
-          "x": 1.25,
-          "y": 3,
-          "w": 2.25
-        },
-        {
-          "matrix": [
-            3,
-            2
-          ],
-          "x": 3.5,
-          "y": 3
-        },
-        {
-          "matrix": [
-            3,
-            3
-          ],
-          "x": 4.5,
-          "y": 3
-        },
-        {
-          "matrix": [
-            3,
-            4
-          ],
-          "x": 5.5,
-          "y": 3
-        },
-        {
-          "matrix": [
-            3,
-            5
-          ],
-          "x": 6.5,
-          "y": 3
-        },
-        {
-          "matrix": [
-            3,
-            6
-          ],
-          "x": 7.5,
-          "y": 3
-        },
-        {
-          "matrix": [
-            8,
-            0
-          ],
-          "x": 8.75,
-          "y": 3
-        },
-        {
-          "matrix": [
-            8,
-            1
-          ],
-          "x": 9.75,
-          "y": 3
-        },
-        {
-          "matrix": [
-            8,
-            2
-          ],
-          "x": 10.75,
-          "y": 3
-        },
-        {
-          "matrix": [
-            8,
-            3
-          ],
-          "x": 11.75,
-          "y": 3
-        },
-        {
-          "matrix": [
-            8,
-            4
-          ],
-          "x": 12.75,
-          "y": 3
-        },
-        {
-          "matrix": [
-            8,
-            5
-          ],
-          "x": 13.75,
-          "y": 3
-        },
-        {
-          "matrix": [
-            8,
-            6
-          ],
-          "x": 14.75,
-          "y": 3
-        },
-        {
-          "matrix": [
-            8,
-            7
-          ],
-          "x": 15.75,
-          "y": 3
-        },
-        {
-          "matrix": [
-            8,
-            8
-          ],
-          "x": 16.75,
-          "y": 3
-        },
-        {
-          "matrix": [
-            4,
-            0
-          ],
-          "x": 0,
-          "y": 4
-        },
-        {
-          "matrix": [
-            4,
-            1
-          ],
-          "x": 1.25,
-          "y": 4,
-          "w": 1.25
-        },
-        {
-          "matrix": [
-            4,
-            2
-          ],
-          "x": 2.5,
-          "y": 4,
-          "w": 1.25
-        },
-        {
-          "matrix": [
-            4,
-            3
-          ],
-          "x": 3.75,
-          "y": 4,
-          "w": 1.25
-        },
-        {
-          "matrix": [
-            4,
-            5
-          ],
-          "x": 5.25,
-          "y": 4,
-          "w": 3
-        },
-        {
-          "matrix": [
-            9,
-            1
-          ],
-          "x": 9,
-          "y": 4,
-          "w": 2.75
-        },
-        {
-          "matrix": [
-            9,
-            3
-          ],
-          "x": 11.75,
-          "y": 4,
-          "w": 1.25
-        },
-        {
-          "matrix": [
-            9,
-            4
-          ],
-          "x": 13,
-          "y": 4,
-          "w": 1.25
-        },
-        {
-          "matrix": [
-            9,
-            6
-          ],
-          "x": 14.75,
-          "y": 4
-        },
-        {
-          "matrix": [
-            9,
-            7
-          ],
-          "x": 15.75,
-          "y": 4
-        },
-        {
-          "matrix": [
-            9,
-            8
-          ],
-          "x": 16.75,
-          "y": 4
+        "matrix": [0, 0]
+    },
+    "debounce": 1,
+    "diode_direction": "ROW2COL",
+    "dynamic_keymap": {
+        "layer_count": 4
+    },
+    "eeprom": {
+        "driver": "wear_leveling",
+        "wear_leveling": {
+            "backing_size": 4096,
+            "driver": "spi_flash"
         }
-      ]
+    },
+    "encoder": {
+        "rotary": [
+            {
+                "pin_a": "B7",
+                "pin_b": "B6"
+            }
+        ]
+    },
+    "features": {
+        "command": false,
+        "console": false,
+        "deferred_exec": true,
+        "encoder": true,
+        "extrakey": true,
+        "mousekey": true,
+        "nkro": true,
+        "rgb_matrix": true,
+        "rgblight": false
+    },
+    "keycodes": [
+        {
+            "key": "KC_BT1"
+        },
+        {
+            "key": "KC_BT2"
+        },
+        {
+            "key": "KC_BT3"
+        },
+        {
+            "key": "KC_2G4"
+        },
+        {
+            "key": "RL_MOD"
+        },
+        {
+            "key": "HS_BATQ"
+        },
+        {
+            "key": "KC_FILP"
+        },
+        {
+            "key": "KC_BATQ"
+        }
+    ],
+    "matrix_pins": {
+        "cols": ["C0", "C1", "C2", "C3", "A6", "B10", "B11", "B12", null],
+        "rows": ["A1", "A2", "A3", "A4", "C13"]
+    },
+    "processor": "WB32FQ95",
+    "rgb_matrix": {
+        "animations": {
+            "solid_color": true,
+            "alphas_mods": true,
+            "gradient_up_down": true,
+            "gradient_left_right": true,
+            "breathing": true,
+            "band_sat": true,
+            "band_val": true,
+            "band_pinwheel_sat": true,
+            "band_pinwheel_val": true,
+            "band_spiral_sat": true,
+            "band_spiral_val": true,
+            "cycle_all": true,
+            "cycle_left_right": true,
+            "cycle_up_down": true,
+            "cycle_out_in": true,
+            "cycle_out_in_dual": true,
+            "rainbow_moving_chevron": true,
+            "cycle_pinwheel": true,
+            "cycle_spiral": true,
+            "dual_beacon": true,
+            "rainbow_beacon": true,
+            "rainbow_pinwheels": true,
+            "flower_blooming": true,
+            "raindrops": true,
+            "jellybean_raindrops": true,
+            "hue_breathing": true,
+            "hue_pendulum": true,
+            "hue_wave": true,
+            "pixel_fractal": true,
+            "pixel_flow": true,
+            "pixel_rain": true,
+            "typing_heatmap": true,
+            "digital_rain": true,
+            "solid_reactive_simple": true,
+            "solid_reactive": true,
+            "solid_reactive_wide": true,
+            "solid_reactive_multiwide": true,
+            "solid_reactive_cross": true,
+            "solid_reactive_multicross": true,
+            "solid_reactive_nexus": true,
+            "solid_reactive_multinexus": true,
+            "splash": true,
+            "multisplash": true,
+            "solid_splash": true,
+            "solid_multisplash": true,
+            "starlight": true,
+            "starlight_smooth": true,
+            "starlight_dual_hue": true,
+            "starlight_dual_sat": true,
+            "riverflow": true
+        },
+        "default": {
+            "animation": "cycle_left_right",
+            "speed": 204,
+            "val": 80
+        },
+        "driver": "ws2812",
+        "layout": [
+            {
+                "matrix": [0, 0],
+                "x": 0,
+                "y": 0,
+                "flags": 4
+            },
+            {
+                "matrix": [0, 0],
+                "x": 0,
+                "y": 0,
+                "flags": 4
+            },
+            {
+                "matrix": [0, 0],
+                "x": 0,
+                "y": 0,
+                "flags": 4
+            },
+            {
+                "matrix": [0, 1],
+                "x": 0,
+                "y": 14,
+                "flags": 4
+            },
+            {
+                "matrix": [0, 2],
+                "x": 0,
+                "y": 28,
+                "flags": 4
+            },
+            {
+                "matrix": [0, 3],
+                "x": 0,
+                "y": 42,
+                "flags": 4
+            },
+            {
+                "matrix": [0, 4],
+                "x": 0,
+                "y": 56,
+                "flags": 4
+            },
+            {
+                "matrix": [0, 5],
+                "x": 0,
+                "y": 70,
+                "flags": 4
+            },
+            {
+                "matrix": [0, 6],
+                "x": 0,
+                "y": 84,
+                "flags": 4
+            },
+            {
+                "matrix": [0, 7],
+                "x": 0,
+                "y": 98,
+                "flags": 4
+            },
+            {
+                "matrix": [1, 6],
+                "x": 16,
+                "y": 84,
+                "flags": 4
+            },
+            {
+                "matrix": [1, 5],
+                "x": 16,
+                "y": 70,
+                "flags": 4
+            },
+            {
+                "matrix": [1, 4],
+                "x": 16,
+                "y": 56,
+                "flags": 4
+            },
+            {
+                "matrix": [1, 3],
+                "x": 16,
+                "y": 42,
+                "flags": 4
+            },
+            {
+                "matrix": [1, 2],
+                "x": 16,
+                "y": 28,
+                "flags": 4
+            },
+            {
+                "matrix": [1, 1],
+                "x": 16,
+                "y": 14,
+                "flags": 4
+            },
+            {
+                "matrix": [1, 0],
+                "x": 16,
+                "y": 0,
+                "flags": 4
+            },
+            {
+                "matrix": [2, 0],
+                "x": 32,
+                "y": 0,
+                "flags": 4
+            },
+            {
+                "matrix": [2, 1],
+                "x": 32,
+                "y": 14,
+                "flags": 4
+            },
+            {
+                "matrix": [2, 2],
+                "x": 32,
+                "y": 28,
+                "flags": 4
+            },
+            {
+                "matrix": [2, 3],
+                "x": 32,
+                "y": 42,
+                "flags": 4
+            },
+            {
+                "matrix": [2, 4],
+                "x": 32,
+                "y": 56,
+                "flags": 4
+            },
+            {
+                "matrix": [2, 5],
+                "x": 32,
+                "y": 70,
+                "flags": 4
+            },
+            {
+                "matrix": [2, 6],
+                "x": 32,
+                "y": 84,
+                "flags": 4
+            },
+            {
+                "matrix": [3, 6],
+                "x": 48,
+                "y": 84,
+                "flags": 4
+            },
+            {
+                "matrix": [3, 5],
+                "x": 48,
+                "y": 70,
+                "flags": 4
+            },
+            {
+                "matrix": [3, 4],
+                "x": 48,
+                "y": 56,
+                "flags": 4
+            },
+            {
+                "matrix": [3, 3],
+                "x": 48,
+                "y": 42,
+                "flags": 4
+            },
+            {
+                "matrix": [3, 2],
+                "x": 48,
+                "y": 28,
+                "flags": 4
+            },
+            {
+                "matrix": [3, 1],
+                "x": 48,
+                "y": 14,
+                "flags": 4
+            },
+            {
+                "matrix": [3, 0],
+                "x": 48,
+                "y": 0,
+                "flags": 4
+            },
+            {
+                "matrix": [4, 0],
+                "x": 64,
+                "y": 0,
+                "flags": 4
+            },
+            {
+                "matrix": [4, 1],
+                "x": 64,
+                "y": 14,
+                "flags": 4
+            },
+            {
+                "matrix": [4, 2],
+                "x": 64,
+                "y": 28,
+                "flags": 4
+            },
+            {
+                "matrix": [4, 3],
+                "x": 64,
+                "y": 42,
+                "flags": 4
+            },
+            {
+                "matrix": [4, 5],
+                "x": 64,
+                "y": 70,
+                "flags": 4
+            },
+            {
+                "matrix": [0, 0],
+                "x": 0,
+                "y": 0,
+                "flags": 4
+            },
+            {
+                "matrix": [0, 0],
+                "x": 0,
+                "y": 0,
+                "flags": 4
+            },
+            {
+                "matrix": [0, 0],
+                "x": 0,
+                "y": 0,
+                "flags": 4
+            },
+            {
+                "matrix": [5, 1],
+                "x": 0,
+                "y": 126,
+                "flags": 4
+            },
+            {
+                "matrix": [5, 2],
+                "x": 0,
+                "y": 140,
+                "flags": 4
+            },
+            {
+                "matrix": [5, 3],
+                "x": 0,
+                "y": 154,
+                "flags": 4
+            },
+            {
+                "matrix": [5, 4],
+                "x": 0,
+                "y": 168,
+                "flags": 4
+            },
+            {
+                "matrix": [5, 5],
+                "x": 0,
+                "y": 182,
+                "flags": 4
+            },
+            {
+                "matrix": [5, 6],
+                "x": 0,
+                "y": 196,
+                "flags": 4
+            },
+            {
+                "matrix": [5, 7],
+                "x": 0,
+                "y": 210,
+                "flags": 4
+            },
+            {
+                "matrix": [5, 8],
+                "x": 0,
+                "y": 224,
+                "flags": 4
+            },
+            {
+                "matrix": [6, 8],
+                "x": 16,
+                "y": 224,
+                "flags": 4
+            },
+            {
+                "matrix": [6, 7],
+                "x": 16,
+                "y": 210,
+                "flags": 4
+            },
+            {
+                "matrix": [6, 6],
+                "x": 16,
+                "y": 196,
+                "flags": 4
+            },
+            {
+                "matrix": [6, 5],
+                "x": 16,
+                "y": 182,
+                "flags": 4
+            },
+            {
+                "matrix": [6, 4],
+                "x": 16,
+                "y": 168,
+                "flags": 4
+            },
+            {
+                "matrix": [6, 3],
+                "x": 16,
+                "y": 154,
+                "flags": 4
+            },
+            {
+                "matrix": [6, 2],
+                "x": 16,
+                "y": 140,
+                "flags": 4
+            },
+            {
+                "matrix": [6, 1],
+                "x": 16,
+                "y": 126,
+                "flags": 4
+            },
+            {
+                "matrix": [7, 1],
+                "x": 32,
+                "y": 126,
+                "flags": 4
+            },
+            {
+                "matrix": [7, 2],
+                "x": 32,
+                "y": 140,
+                "flags": 4
+            },
+            {
+                "matrix": [7, 3],
+                "x": 32,
+                "y": 154,
+                "flags": 4
+            },
+            {
+                "matrix": [7, 4],
+                "x": 32,
+                "y": 168,
+                "flags": 4
+            },
+            {
+                "matrix": [7, 5],
+                "x": 32,
+                "y": 182,
+                "flags": 4
+            },
+            {
+                "matrix": [7, 6],
+                "x": 32,
+                "y": 196,
+                "flags": 4
+            },
+            {
+                "matrix": [7, 7],
+                "x": 32,
+                "y": 210,
+                "flags": 4
+            },
+            {
+                "matrix": [8, 8],
+                "x": 48,
+                "y": 224,
+                "flags": 4
+            },
+            {
+                "matrix": [8, 7],
+                "x": 48,
+                "y": 210,
+                "flags": 4
+            },
+            {
+                "matrix": [8, 6],
+                "x": 48,
+                "y": 196,
+                "flags": 4
+            },
+            {
+                "matrix": [8, 5],
+                "x": 48,
+                "y": 182,
+                "flags": 4
+            },
+            {
+                "matrix": [8, 4],
+                "x": 48,
+                "y": 168,
+                "flags": 4
+            },
+            {
+                "matrix": [8, 3],
+                "x": 48,
+                "y": 154,
+                "flags": 4
+            },
+            {
+                "matrix": [8, 2],
+                "x": 48,
+                "y": 140,
+                "flags": 4
+            },
+            {
+                "matrix": [8, 1],
+                "x": 48,
+                "y": 126,
+                "flags": 4
+            },
+            {
+                "matrix": [8, 0],
+                "x": 48,
+                "y": 112,
+                "flags": 4
+            },
+            {
+                "matrix": [9, 1],
+                "x": 64,
+                "y": 126,
+                "flags": 4
+            },
+            {
+                "matrix": [9, 3],
+                "x": 64,
+                "y": 154,
+                "flags": 4
+            },
+            {
+                "matrix": [9, 4],
+                "x": 64,
+                "y": 168,
+                "flags": 4
+            },
+            {
+                "matrix": [9, 6],
+                "x": 64,
+                "y": 196,
+                "flags": 4
+            },
+            {
+                "matrix": [9, 7],
+                "x": 64,
+                "y": 210,
+                "flags": 4
+            },
+            {
+                "matrix": [9, 8],
+                "x": 64,
+                "y": 224,
+                "flags": 4
+            }
+        ],
+        "max_brightness": 80,
+        "sleep": true,
+        "speed_steps": 51,
+        "val_steps": 16,
+        "split_count": [36, 41]
+    },
+    "split": {
+        "enabled": true,
+        "transport": {
+            "sync": {
+                "activity": true,
+                "detected_os": true,
+                "layer_state": true,
+                "indicators": true,
+                "matrix_state": true,
+                "modifiers": true
+            }
+        },
+        "matrix_pins": {
+            "right": {
+                "cols": [
+                    "B13",
+                    "B14",
+                    "C6",
+                    "C7",
+                    "C8",
+                    "C9",
+                    "C4",
+                    "C5",
+                    "B0"
+                ],
+                "rows": ["A1", "A2", "A3", "A4", "C13"]
+            }
+        },
+        "serial": {
+            "driver": "usart"
+        },
+        "bootmagic": {
+            "matrix": [9, 0]
+        }
+    },
+    "tap_keycode_delay": 10,
+    "url": "https://epomaker.com/products/epomaker-split-70",
+    "usb": {
+        "device_version": "0.3.0",
+        "force_nkro": true,
+        "pid": "0xE491",
+        "suspend_wakeup_delay": 1000,
+        "vid": "0x342D"
+    },
+    "ws2812": {
+        "driver": "spi",
+        "pin": "B15"
+    },
+    "layouts": {
+        "LAYOUT": {
+            "layout": [
+                {
+                    "matrix": [0, 0],
+                    "x": 0,
+                    "y": 0
+                },
+                {
+                    "matrix": [0, 1],
+                    "x": 1.25,
+                    "y": 0
+                },
+                {
+                    "matrix": [0, 2],
+                    "x": 2.25,
+                    "y": 0
+                },
+                {
+                    "matrix": [0, 3],
+                    "x": 3.25,
+                    "y": 0
+                },
+                {
+                    "matrix": [0, 4],
+                    "x": 4.25,
+                    "y": 0
+                },
+                {
+                    "matrix": [0, 5],
+                    "x": 5.25,
+                    "y": 0
+                },
+                {
+                    "matrix": [0, 6],
+                    "x": 6.25,
+                    "y": 0
+                },
+                {
+                    "matrix": [0, 7],
+                    "x": 7.25,
+                    "y": 0
+                },
+                {
+                    "matrix": [5, 1],
+                    "x": 8.75,
+                    "y": 0
+                },
+                {
+                    "matrix": [5, 2],
+                    "x": 9.75,
+                    "y": 0
+                },
+                {
+                    "matrix": [5, 3],
+                    "x": 10.75,
+                    "y": 0
+                },
+                {
+                    "matrix": [5, 4],
+                    "x": 11.75,
+                    "y": 0
+                },
+                {
+                    "matrix": [5, 5],
+                    "x": 12.75,
+                    "y": 0
+                },
+                {
+                    "matrix": [5, 6],
+                    "x": 13.75,
+                    "y": 0
+                },
+                {
+                    "matrix": [5, 7],
+                    "x": 14.75,
+                    "y": 0
+                },
+                {
+                    "matrix": [5, 8],
+                    "x": 15.75,
+                    "y": 0,
+                    "w": 2
+                },
+                {
+                    "matrix": [1, 0],
+                    "x": 0,
+                    "y": 1
+                },
+                {
+                    "matrix": [1, 1],
+                    "x": 1.25,
+                    "y": 1,
+                    "w": 1.5
+                },
+                {
+                    "matrix": [1, 2],
+                    "x": 2.75,
+                    "y": 1
+                },
+                {
+                    "matrix": [1, 3],
+                    "x": 3.75,
+                    "y": 1
+                },
+                {
+                    "matrix": [1, 4],
+                    "x": 4.75,
+                    "y": 1
+                },
+                {
+                    "matrix": [1, 5],
+                    "x": 5.75,
+                    "y": 1
+                },
+                {
+                    "matrix": [1, 6],
+                    "x": 6.75,
+                    "y": 1
+                },
+                {
+                    "matrix": [6, 1],
+                    "x": 9.25,
+                    "y": 1
+                },
+                {
+                    "matrix": [6, 2],
+                    "x": 10.25,
+                    "y": 1
+                },
+                {
+                    "matrix": [6, 3],
+                    "x": 11.25,
+                    "y": 1
+                },
+                {
+                    "matrix": [6, 4],
+                    "x": 12.25,
+                    "y": 1
+                },
+                {
+                    "matrix": [6, 5],
+                    "x": 13.25,
+                    "y": 1
+                },
+                {
+                    "matrix": [6, 6],
+                    "x": 14.25,
+                    "y": 1
+                },
+                {
+                    "matrix": [6, 7],
+                    "x": 15.25,
+                    "y": 1
+                },
+                {
+                    "matrix": [6, 8],
+                    "x": 16.25,
+                    "y": 1,
+                    "w": 1.5
+                },
+                {
+                    "matrix": [2, 0],
+                    "x": 0,
+                    "y": 2
+                },
+                {
+                    "matrix": [2, 1],
+                    "x": 1.25,
+                    "y": 2,
+                    "w": 1.75
+                },
+                {
+                    "matrix": [2, 2],
+                    "x": 3,
+                    "y": 2
+                },
+                {
+                    "matrix": [2, 3],
+                    "x": 4,
+                    "y": 2
+                },
+                {
+                    "matrix": [2, 4],
+                    "x": 5,
+                    "y": 2
+                },
+                {
+                    "matrix": [2, 5],
+                    "x": 6,
+                    "y": 2
+                },
+                {
+                    "matrix": [2, 6],
+                    "x": 7,
+                    "y": 2
+                },
+                {
+                    "matrix": [7, 1],
+                    "x": 9.5,
+                    "y": 2
+                },
+                {
+                    "matrix": [7, 2],
+                    "x": 10.5,
+                    "y": 2
+                },
+                {
+                    "matrix": [7, 3],
+                    "x": 11.5,
+                    "y": 2
+                },
+                {
+                    "matrix": [7, 4],
+                    "x": 12.5,
+                    "y": 2
+                },
+                {
+                    "matrix": [7, 5],
+                    "x": 13.5,
+                    "y": 2
+                },
+                {
+                    "matrix": [7, 6],
+                    "x": 14.5,
+                    "y": 2
+                },
+                {
+                    "matrix": [7, 7],
+                    "x": 15.5,
+                    "y": 2,
+                    "w": 2.25
+                },
+                {
+                    "matrix": [3, 0],
+                    "x": 0,
+                    "y": 3
+                },
+                {
+                    "matrix": [3, 1],
+                    "x": 1.25,
+                    "y": 3,
+                    "w": 2.25
+                },
+                {
+                    "matrix": [3, 2],
+                    "x": 3.5,
+                    "y": 3
+                },
+                {
+                    "matrix": [3, 3],
+                    "x": 4.5,
+                    "y": 3
+                },
+                {
+                    "matrix": [3, 4],
+                    "x": 5.5,
+                    "y": 3
+                },
+                {
+                    "matrix": [3, 5],
+                    "x": 6.5,
+                    "y": 3
+                },
+                {
+                    "matrix": [3, 6],
+                    "x": 7.5,
+                    "y": 3
+                },
+                {
+                    "matrix": [8, 0],
+                    "x": 8.75,
+                    "y": 3
+                },
+                {
+                    "matrix": [8, 1],
+                    "x": 9.75,
+                    "y": 3
+                },
+                {
+                    "matrix": [8, 2],
+                    "x": 10.75,
+                    "y": 3
+                },
+                {
+                    "matrix": [8, 3],
+                    "x": 11.75,
+                    "y": 3
+                },
+                {
+                    "matrix": [8, 4],
+                    "x": 12.75,
+                    "y": 3
+                },
+                {
+                    "matrix": [8, 5],
+                    "x": 13.75,
+                    "y": 3
+                },
+                {
+                    "matrix": [8, 6],
+                    "x": 14.75,
+                    "y": 3
+                },
+                {
+                    "matrix": [8, 7],
+                    "x": 15.75,
+                    "y": 3
+                },
+                {
+                    "matrix": [8, 8],
+                    "x": 16.75,
+                    "y": 3
+                },
+                {
+                    "matrix": [4, 0],
+                    "x": 0,
+                    "y": 4
+                },
+                {
+                    "matrix": [4, 1],
+                    "x": 1.25,
+                    "y": 4,
+                    "w": 1.25
+                },
+                {
+                    "matrix": [4, 2],
+                    "x": 2.5,
+                    "y": 4,
+                    "w": 1.25
+                },
+                {
+                    "matrix": [4, 3],
+                    "x": 3.75,
+                    "y": 4,
+                    "w": 1.25
+                },
+                {
+                    "matrix": [4, 5],
+                    "x": 5.25,
+                    "y": 4,
+                    "w": 3
+                },
+                {
+                    "matrix": [9, 1],
+                    "x": 9,
+                    "y": 4,
+                    "w": 2.75
+                },
+                {
+                    "matrix": [9, 3],
+                    "x": 11.75,
+                    "y": 4,
+                    "w": 1.25
+                },
+                {
+                    "matrix": [9, 4],
+                    "x": 13,
+                    "y": 4,
+                    "w": 1.25
+                },
+                {
+                    "matrix": [9, 6],
+                    "x": 14.75,
+                    "y": 4
+                },
+                {
+                    "matrix": [9, 7],
+                    "x": 15.75,
+                    "y": 4
+                },
+                {
+                    "matrix": [9, 8],
+                    "x": 16.75,
+                    "y": 4
+                }
+            ]
+        }
     }
-  }
 }

--- a/keyboards/epomaker/split70/keyboard.json
+++ b/keyboards/epomaker/split70/keyboard.json
@@ -1,0 +1,1505 @@
+{
+  "manufacturer": "Epomaker",
+  "keyboard_name": "Epomaker Split70",
+  "maintainer": "Epomaker",
+  "bootloader": "wb32-dfu",
+  "bootmagic": {
+    "matrix": [
+      0,
+      0
+    ]
+  },
+  "debounce": 1,
+  "diode_direction": "ROW2COL",
+  "dynamic_keymap": {
+    "layer_count": 4
+  },
+  "eeprom": {
+    "driver": "wear_leveling",
+    "wear_leveling": {
+      "backing_size": 4096,
+      "driver": "spi_flash"
+    }
+  },
+  "encoder": {
+    "rotary": [
+      {
+        "pin_a": "B7",
+        "pin_b": "B6"
+      }
+    ]
+  },
+  "features": {
+    "command": false,
+    "console": false,
+    "deferred_exec": true,
+    "encoder": true,
+    "extrakey": true,
+    "mousekey": true,
+    "nkro": true,
+    "rgb_matrix": true,
+      "rgblight": false
+  },
+  "keycodes": [
+    {
+      "key": "KC_BT1"
+    },
+    {
+      "key": "KC_BT2"
+    },
+    {
+      "key": "KC_BT3"
+    },
+    {
+      "key": "KC_2G4"
+    },
+    {
+      "key": "RL_MOD"
+    },
+    {
+      "key": "HS_BATQ"
+    },
+    {
+      "key": "KC_FILP"
+    },
+    {
+      "key": "KC_BATQ"
+    }
+  ],
+  "matrix_pins": {
+    "cols": [
+      "C0",
+      "C1",
+      "C2",
+      "C3",
+      "A6",
+      "B10",
+      "B11",
+      "B12",
+      null
+    ],
+    "rows": [
+      "A1",
+      "A2",
+      "A3",
+      "A4",
+      "C13"
+    ]
+  },
+  "processor": "WB32FQ95",
+  "rgb_matrix": {
+    "animations": {
+      "solid_color": true,
+      "alphas_mods": true,
+      "gradient_up_down": true,
+      "gradient_left_right": true,
+      "breathing": true,
+      "band_sat": true,
+      "band_val": true,
+      "band_pinwheel_sat": true,
+      "band_pinwheel_val": true,
+      "band_spiral_sat": true,
+      "band_spiral_val": true,
+      "cycle_all": true,
+      "cycle_left_right": true,
+      "cycle_up_down": true,
+      "cycle_out_in": true,
+      "cycle_out_in_dual": true,
+      "rainbow_moving_chevron": true,
+      "cycle_pinwheel": true,
+      "cycle_spiral": true,
+      "dual_beacon": true,
+      "rainbow_beacon": true,
+      "rainbow_pinwheels": true,
+      "flower_blooming": true,
+      "raindrops": true,
+      "jellybean_raindrops": true,
+      "hue_breathing": true,
+      "hue_pendulum": true,
+      "hue_wave": true,
+      "pixel_fractal": true,
+      "pixel_flow": true,
+      "pixel_rain": true,
+      "typing_heatmap": true,
+      "digital_rain": true,
+      "solid_reactive_simple": true,
+      "solid_reactive": true,
+      "solid_reactive_wide": true,
+      "solid_reactive_multiwide": true,
+      "solid_reactive_cross": true,
+      "solid_reactive_multicross": true,
+      "solid_reactive_nexus": true,
+      "solid_reactive_multinexus": true,
+      "splash": true,
+      "multisplash": true,
+      "solid_splash": true,
+      "solid_multisplash": true,
+      "starlight": true,
+      "starlight_smooth": true,
+      "starlight_dual_hue": true,
+      "starlight_dual_sat": true,
+      "riverflow": true
+    },
+    "default": {
+      "animation": "cycle_left_right",
+      "speed": 204,
+      "val": 80
+    },
+    "driver": "ws2812",
+    "layout": [
+      {
+        "matrix": [
+          0,
+          0
+        ],
+        "x": 0,
+        "y": 0,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          0,
+          0
+        ],
+        "x": 0,
+        "y": 0,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          0,
+          0
+        ],
+        "x": 0,
+        "y": 0,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          0,
+          1
+        ],
+        "x": 0,
+        "y": 14,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          0,
+          2
+        ],
+        "x": 0,
+        "y": 28,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          0,
+          3
+        ],
+        "x": 0,
+        "y": 42,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          0,
+          4
+        ],
+        "x": 0,
+        "y": 56,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          0,
+          5
+        ],
+        "x": 0,
+        "y": 70,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          0,
+          6
+        ],
+        "x": 0,
+        "y": 84,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          0,
+          7
+        ],
+        "x": 0,
+        "y": 98,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          1,
+          6
+        ],
+        "x": 16,
+        "y": 84,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          1,
+          5
+        ],
+        "x": 16,
+        "y": 70,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          1,
+          4
+        ],
+        "x": 16,
+        "y": 56,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          1,
+          3
+        ],
+        "x": 16,
+        "y": 42,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          1,
+          2
+        ],
+        "x": 16,
+        "y": 28,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          1,
+          1
+        ],
+        "x": 16,
+        "y": 14,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          1,
+          0
+        ],
+        "x": 16,
+        "y": 0,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          2,
+          0
+        ],
+        "x": 32,
+        "y": 0,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          2,
+          1
+        ],
+        "x": 32,
+        "y": 14,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          2,
+          2
+        ],
+        "x": 32,
+        "y": 28,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          2,
+          3
+        ],
+        "x": 32,
+        "y": 42,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          2,
+          4
+        ],
+        "x": 32,
+        "y": 56,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          2,
+          5
+        ],
+        "x": 32,
+        "y": 70,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          2,
+          6
+        ],
+        "x": 32,
+        "y": 84,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          3,
+          6
+        ],
+        "x": 48,
+        "y": 84,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          3,
+          5
+        ],
+        "x": 48,
+        "y": 70,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          3,
+          4
+        ],
+        "x": 48,
+        "y": 56,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          3,
+          3
+        ],
+        "x": 48,
+        "y": 42,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          3,
+          2
+        ],
+        "x": 48,
+        "y": 28,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          3,
+          1
+        ],
+        "x": 48,
+        "y": 14,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          3,
+          0
+        ],
+        "x": 48,
+        "y": 0,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          4,
+          0
+        ],
+        "x": 64,
+        "y": 0,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          4,
+          1
+        ],
+        "x": 64,
+        "y": 14,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          4,
+          2
+        ],
+        "x": 64,
+        "y": 28,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          4,
+          3
+        ],
+        "x": 64,
+        "y": 42,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          4,
+          5
+        ],
+        "x": 64,
+        "y": 70,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          0,
+          0
+        ],
+        "x": 0,
+        "y": 0,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          0,
+          0
+        ],
+        "x": 0,
+        "y": 0,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          0,
+          0
+        ],
+        "x": 0,
+        "y": 0,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          5,
+          1
+        ],
+        "x": 0,
+        "y": 126,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          5,
+          2
+        ],
+        "x": 0,
+        "y": 140,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          5,
+          3
+        ],
+        "x": 0,
+        "y": 154,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          5,
+          4
+        ],
+        "x": 0,
+        "y": 168,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          5,
+          5
+        ],
+        "x": 0,
+        "y": 182,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          5,
+          6
+        ],
+        "x": 0,
+        "y": 196,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          5,
+          7
+        ],
+        "x": 0,
+        "y": 210,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          5,
+          8
+        ],
+        "x": 0,
+        "y": 224,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          6,
+          8
+        ],
+        "x": 16,
+        "y": 224,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          6,
+          7
+        ],
+        "x": 16,
+        "y": 210,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          6,
+          6
+        ],
+        "x": 16,
+        "y": 196,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          6,
+          5
+        ],
+        "x": 16,
+        "y": 182,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          6,
+          4
+        ],
+        "x": 16,
+        "y": 168,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          6,
+          3
+        ],
+        "x": 16,
+        "y": 154,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          6,
+          2
+        ],
+        "x": 16,
+        "y": 140,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          6,
+          1
+        ],
+        "x": 16,
+        "y": 126,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          7,
+          1
+        ],
+        "x": 32,
+        "y": 126,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          7,
+          2
+        ],
+        "x": 32,
+        "y": 140,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          7,
+          3
+        ],
+        "x": 32,
+        "y": 154,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          7,
+          4
+        ],
+        "x": 32,
+        "y": 168,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          7,
+          5
+        ],
+        "x": 32,
+        "y": 182,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          7,
+          6
+        ],
+        "x": 32,
+        "y": 196,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          7,
+          7
+        ],
+        "x": 32,
+        "y": 210,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          8,
+          8
+        ],
+        "x": 48,
+        "y": 224,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          8,
+          7
+        ],
+        "x": 48,
+        "y": 210,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          8,
+          6
+        ],
+        "x": 48,
+        "y": 196,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          8,
+          5
+        ],
+        "x": 48,
+        "y": 182,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          8,
+          4
+        ],
+        "x": 48,
+        "y": 168,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          8,
+          3
+        ],
+        "x": 48,
+        "y": 154,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          8,
+          2
+        ],
+        "x": 48,
+        "y": 140,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          8,
+          1
+        ],
+        "x": 48,
+        "y": 126,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          8,
+          0
+        ],
+        "x": 48,
+        "y": 112,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          9,
+          1
+        ],
+        "x": 64,
+        "y": 126,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          9,
+          3
+        ],
+        "x": 64,
+        "y": 154,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          9,
+          4
+        ],
+        "x": 64,
+        "y": 168,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          9,
+          6
+        ],
+        "x": 64,
+        "y": 196,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          9,
+          7
+        ],
+        "x": 64,
+        "y": 210,
+        "flags": 4
+      },
+      {
+        "matrix": [
+          9,
+          8
+        ],
+        "x": 64,
+        "y": 224,
+        "flags": 4
+      }
+    ],
+    "max_brightness": 80,
+    "sleep": true,
+    "speed_steps": 51,
+    "val_steps": 16,
+    "split_count": [
+      36,
+      41
+    ]
+  },
+  "split": {
+    "enabled": true,
+    "transport": {
+      "sync": {
+        "activity": true,
+        "detected_os": true,
+        "layer_state": true,
+        "indicators": true,
+        "matrix_state": true,
+        "modifiers": true
+      }
+    },
+    "matrix_pins": {
+      "right": {
+        "cols": [
+          "B13",
+          "B14",
+          "C6",
+          "C7",
+          "C8",
+          "C9",
+          "C4",
+          "C5",
+          "B0"
+        ],
+        "rows": [
+          "A1",
+          "A2",
+          "A3",
+          "A4",
+          "C13"
+        ]
+      }
+    },
+    "serial": {
+      "driver": "usart"
+    },
+    "bootmagic": {
+      "matrix": [
+        5,
+        1
+      ]
+    }
+  },
+  "tap_keycode_delay": 10,
+  "url": "https://epomaker.com/products/epomaker-split-70",
+  "usb": {
+    "device_version": "0.3.0",
+    "force_nkro": true,
+    "pid": "0xE491",
+    "suspend_wakeup_delay": 1000,
+    "vid": "0x342D"
+  },
+  "ws2812": {
+    "driver": "spi",
+    "pin": "B15"
+  },
+  "layouts": {
+    "LAYOUT": {
+      "layout": [
+        {
+          "matrix": [
+            0,
+            0
+          ],
+          "x": 0,
+          "y": 0
+        },
+        {
+          "matrix": [
+            0,
+            1
+          ],
+          "x": 1.25,
+          "y": 0
+        },
+        {
+          "matrix": [
+            0,
+            2
+          ],
+          "x": 2.25,
+          "y": 0
+        },
+        {
+          "matrix": [
+            0,
+            3
+          ],
+          "x": 3.25,
+          "y": 0
+        },
+        {
+          "matrix": [
+            0,
+            4
+          ],
+          "x": 4.25,
+          "y": 0
+        },
+        {
+          "matrix": [
+            0,
+            5
+          ],
+          "x": 5.25,
+          "y": 0
+        },
+        {
+          "matrix": [
+            0,
+            6
+          ],
+          "x": 6.25,
+          "y": 0
+        },
+        {
+          "matrix": [
+            0,
+            7
+          ],
+          "x": 7.25,
+          "y": 0
+        },
+        {
+          "matrix": [
+            5,
+            1
+          ],
+          "x": 8.75,
+          "y": 0
+        },
+        {
+          "matrix": [
+            5,
+            2
+          ],
+          "x": 9.75,
+          "y": 0
+        },
+        {
+          "matrix": [
+            5,
+            3
+          ],
+          "x": 10.75,
+          "y": 0
+        },
+        {
+          "matrix": [
+            5,
+            4
+          ],
+          "x": 11.75,
+          "y": 0
+        },
+        {
+          "matrix": [
+            5,
+            5
+          ],
+          "x": 12.75,
+          "y": 0
+        },
+        {
+          "matrix": [
+            5,
+            6
+          ],
+          "x": 13.75,
+          "y": 0
+        },
+        {
+          "matrix": [
+            5,
+            7
+          ],
+          "x": 14.75,
+          "y": 0
+        },
+        {
+          "matrix": [
+            5,
+            8
+          ],
+          "x": 15.75,
+          "y": 0,
+          "w": 2
+        },
+        {
+          "matrix": [
+            1,
+            0
+          ],
+          "x": 0,
+          "y": 1
+        },
+        {
+          "matrix": [
+            1,
+            1
+          ],
+          "x": 1.25,
+          "y": 1,
+          "w": 1.5
+        },
+        {
+          "matrix": [
+            1,
+            2
+          ],
+          "x": 2.75,
+          "y": 1
+        },
+        {
+          "matrix": [
+            1,
+            3
+          ],
+          "x": 3.75,
+          "y": 1
+        },
+        {
+          "matrix": [
+            1,
+            4
+          ],
+          "x": 4.75,
+          "y": 1
+        },
+        {
+          "matrix": [
+            1,
+            5
+          ],
+          "x": 5.75,
+          "y": 1
+        },
+        {
+          "matrix": [
+            1,
+            6
+          ],
+          "x": 6.75,
+          "y": 1
+        },
+        {
+          "matrix": [
+            6,
+            1
+          ],
+          "x": 9.25,
+          "y": 1
+        },
+        {
+          "matrix": [
+            6,
+            2
+          ],
+          "x": 10.25,
+          "y": 1
+        },
+        {
+          "matrix": [
+            6,
+            3
+          ],
+          "x": 11.25,
+          "y": 1
+        },
+        {
+          "matrix": [
+            6,
+            4
+          ],
+          "x": 12.25,
+          "y": 1
+        },
+        {
+          "matrix": [
+            6,
+            5
+          ],
+          "x": 13.25,
+          "y": 1
+        },
+        {
+          "matrix": [
+            6,
+            6
+          ],
+          "x": 14.25,
+          "y": 1
+        },
+        {
+          "matrix": [
+            6,
+            7
+          ],
+          "x": 15.25,
+          "y": 1
+        },
+        {
+          "matrix": [
+            6,
+            8
+          ],
+          "x": 16.25,
+          "y": 1,
+          "w": 1.5
+        },
+        {
+          "matrix": [
+            2,
+            0
+          ],
+          "x": 0,
+          "y": 2
+        },
+        {
+          "matrix": [
+            2,
+            1
+          ],
+          "x": 1.25,
+          "y": 2,
+          "w": 1.75
+        },
+        {
+          "matrix": [
+            2,
+            2
+          ],
+          "x": 3,
+          "y": 2
+        },
+        {
+          "matrix": [
+            2,
+            3
+          ],
+          "x": 4,
+          "y": 2
+        },
+        {
+          "matrix": [
+            2,
+            4
+          ],
+          "x": 5,
+          "y": 2
+        },
+        {
+          "matrix": [
+            2,
+            5
+          ],
+          "x": 6,
+          "y": 2
+        },
+        {
+          "matrix": [
+            2,
+            6
+          ],
+          "x": 7,
+          "y": 2
+        },
+        {
+          "matrix": [
+            7,
+            1
+          ],
+          "x": 9.5,
+          "y": 2
+        },
+        {
+          "matrix": [
+            7,
+            2
+          ],
+          "x": 10.5,
+          "y": 2
+        },
+        {
+          "matrix": [
+            7,
+            3
+          ],
+          "x": 11.5,
+          "y": 2
+        },
+        {
+          "matrix": [
+            7,
+            4
+          ],
+          "x": 12.5,
+          "y": 2
+        },
+        {
+          "matrix": [
+            7,
+            5
+          ],
+          "x": 13.5,
+          "y": 2
+        },
+        {
+          "matrix": [
+            7,
+            6
+          ],
+          "x": 14.5,
+          "y": 2
+        },
+        {
+          "matrix": [
+            7,
+            7
+          ],
+          "x": 15.5,
+          "y": 2,
+          "w": 2.25
+        },
+        {
+          "matrix": [
+            3,
+            0
+          ],
+          "x": 0,
+          "y": 3
+        },
+        {
+          "matrix": [
+            3,
+            1
+          ],
+          "x": 1.25,
+          "y": 3,
+          "w": 2.25
+        },
+        {
+          "matrix": [
+            3,
+            2
+          ],
+          "x": 3.5,
+          "y": 3
+        },
+        {
+          "matrix": [
+            3,
+            3
+          ],
+          "x": 4.5,
+          "y": 3
+        },
+        {
+          "matrix": [
+            3,
+            4
+          ],
+          "x": 5.5,
+          "y": 3
+        },
+        {
+          "matrix": [
+            3,
+            5
+          ],
+          "x": 6.5,
+          "y": 3
+        },
+        {
+          "matrix": [
+            3,
+            6
+          ],
+          "x": 7.5,
+          "y": 3
+        },
+        {
+          "matrix": [
+            8,
+            0
+          ],
+          "x": 8.75,
+          "y": 3
+        },
+        {
+          "matrix": [
+            8,
+            1
+          ],
+          "x": 9.75,
+          "y": 3
+        },
+        {
+          "matrix": [
+            8,
+            2
+          ],
+          "x": 10.75,
+          "y": 3
+        },
+        {
+          "matrix": [
+            8,
+            3
+          ],
+          "x": 11.75,
+          "y": 3
+        },
+        {
+          "matrix": [
+            8,
+            4
+          ],
+          "x": 12.75,
+          "y": 3
+        },
+        {
+          "matrix": [
+            8,
+            5
+          ],
+          "x": 13.75,
+          "y": 3
+        },
+        {
+          "matrix": [
+            8,
+            6
+          ],
+          "x": 14.75,
+          "y": 3
+        },
+        {
+          "matrix": [
+            8,
+            7
+          ],
+          "x": 15.75,
+          "y": 3
+        },
+        {
+          "matrix": [
+            8,
+            8
+          ],
+          "x": 16.75,
+          "y": 3
+        },
+        {
+          "matrix": [
+            4,
+            0
+          ],
+          "x": 0,
+          "y": 4
+        },
+        {
+          "matrix": [
+            4,
+            1
+          ],
+          "x": 1.25,
+          "y": 4,
+          "w": 1.25
+        },
+        {
+          "matrix": [
+            4,
+            2
+          ],
+          "x": 2.5,
+          "y": 4,
+          "w": 1.25
+        },
+        {
+          "matrix": [
+            4,
+            3
+          ],
+          "x": 3.75,
+          "y": 4,
+          "w": 1.25
+        },
+        {
+          "matrix": [
+            4,
+            5
+          ],
+          "x": 5.25,
+          "y": 4,
+          "w": 3
+        },
+        {
+          "matrix": [
+            9,
+            1
+          ],
+          "x": 9,
+          "y": 4,
+          "w": 2.75
+        },
+        {
+          "matrix": [
+            9,
+            3
+          ],
+          "x": 11.75,
+          "y": 4,
+          "w": 1.25
+        },
+        {
+          "matrix": [
+            9,
+            4
+          ],
+          "x": 13,
+          "y": 4,
+          "w": 1.25
+        },
+        {
+          "matrix": [
+            9,
+            6
+          ],
+          "x": 14.75,
+          "y": 4
+        },
+        {
+          "matrix": [
+            9,
+            7
+          ],
+          "x": 15.75,
+          "y": 4
+        },
+        {
+          "matrix": [
+            9,
+            8
+          ],
+          "x": 16.75,
+          "y": 4
+        }
+      ]
+    }
+  }
+}

--- a/keyboards/epomaker/split70/keymaps/default/keymap.c
+++ b/keyboards/epomaker/split70/keymaps/default/keymap.c
@@ -1,0 +1,58 @@
+// Copyright 2024 Epomaker (@Epomaker)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+#include "rgb_record/rgb_record.h"
+
+enum layers {
+    _BL = 0,
+    _FL,
+    _MBL,
+    _MFL,
+};
+
+#define _______ KC_TRNS
+
+// clang-format off
+const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+
+    [_BL] = LAYOUT(
+        KC_MUTE,  QK_GESC,  KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,               KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSPC,
+        MO(_FL),  KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,                         KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSLS,
+        MO(_FL),  KC_CAPS,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,                         KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,            KC_ENT,
+        MO(_FL),  KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,               KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,  KC_UP,    KC_DEL,
+        MO(_FL),  KC_LCTL,  KC_LALT,  KC_LGUI,            KC_SPC,                                 KC_SPC,             KC_RGUI,  KC_RALT,            KC_LEFT,  KC_DOWN,  KC_RGHT),
+
+    [_FL] = LAYOUT(
+        _______, _______, _______,    KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,              KC_F6,    KC_F7,    KC_F8,    KC_F9,      KC_F10,   KC_F11,    KC_F12,   QK_BOOT,
+        _______, RM_NEXT,  KC_BT1,    KC_BT2,   KC_BT3,   KC_2G4,   _______,                      KC_PSCR,  KC_SCRL,  KC_PAUSE, _______,    _______,  RM_HUED,   RM_HUEU,  RL_MOD,
+        _______, _______,  KC_NO,     TO(_MBL), _______,  _______,  _______,                      KC_HOME,  KC_END,   KC_PGUP,  KC_PGDN,    RM_SATD,  RM_SATU,             KC_END,
+        _______, _______,  RM_TOGG,   _______,  _______,  NK_TOGG,  HS_BATQ,            HS_BATQ,  _______,  _______,  _______,  _______,    _______,  _______,   RM_VALU,  KC_INS,
+        _______, KC_FILP,  _______,   _______,            KC_BATQ,                                KC_BATQ,           _______,  GU_TOGG,              RM_SPDD,   RM_VALD,  RM_SPDU),
+
+    [_MBL] = LAYOUT(
+        KC_MUTE, QK_GESC,  KC_GRV,   KC_1,     KC_2,     KC_3,     KC_4,     KC_5,               KC_6,     KC_7,     KC_8,     KC_9,     KC_0,     KC_MINS,  KC_EQL,   KC_BSPC,
+        MO(_MFL),KC_TAB,   KC_Q,     KC_W,     KC_E,     KC_R,     KC_T,                         KC_Y,     KC_U,     KC_I,     KC_O,     KC_P,     KC_LBRC,  KC_RBRC,  KC_BSLS,
+        MO(_MFL),KC_CAPS,  KC_A,     KC_S,     KC_D,     KC_F,     KC_G,                         KC_H,     KC_J,     KC_K,     KC_L,     KC_SCLN,  KC_QUOT,            KC_ENT,
+        MO(_MFL),KC_LSFT,  KC_Z,     KC_X,     KC_C,     KC_V,     KC_B,               KC_B,     KC_N,     KC_M,     KC_COMM,  KC_DOT,   KC_SLSH,  KC_RSFT,  KC_UP,    KC_DEL,
+        MO(_MFL),KC_LCTL,  KC_LGUI,  KC_LALT,            KC_SPC,                                 KC_SPC,            KC_RALT,  KC_RGUI,            KC_LEFT,  KC_DOWN,  KC_RGHT),
+
+    [_MFL] = LAYOUT(
+        _______,  _______, _______,   KC_F1,    KC_F2,    KC_F3,    KC_F4,    KC_F5,              KC_F6,    KC_F7,    KC_F8,   KC_F9,     KC_F10,  KC_F11,    KC_F12,   QK_BOOT,
+        _______,  RM_NEXT, KC_BT1,    KC_BT2,   KC_BT3,   KC_2G4,   _______,                      KC_PSCR,  KC_SCRL,  KC_PAUSE, _______, _______, RM_HUED,   RM_HUEU,  RL_MOD,
+        _______,  TO(_BL), KC_NO,     _______,  _______,  _______,  _______,                      KC_HOME,  KC_END,   KC_PGUP, KC_PGDN, RM_SATD, RM_SATU,             KC_END,
+        _______,  _______, RM_TOGG,   _______,  _______,  _______,  HS_BATQ,            HS_BATQ,  _______,  _______,  _______, _______,   _______, _______, RM_VALU,  KC_INS,
+        _______,  KC_FILP, _______,   _______,            KC_BATQ,                                KC_BATQ,            _______, KC_RALT,            RM_SPDD,   RM_VALD,  RM_SPDU),
+
+};
+
+
+#ifdef ENCODER_MAP_ENABLE
+const uint16_t PROGMEM encoder_map[][NUM_ENCODERS][NUM_DIRECTIONS] = {
+    [0] = {ENCODER_CCW_CW(KC_VOLD, KC_VOLU)},
+    [1] = {ENCODER_CCW_CW(KC_VOLD, KC_VOLU)},
+    [2] = {ENCODER_CCW_CW(KC_VOLD, KC_VOLU)},
+    [3] = {ENCODER_CCW_CW(KC_VOLD, KC_VOLU)},
+};
+#endif
+// clang-format on

--- a/keyboards/epomaker/split70/linker/wireless/lowpower.c
+++ b/keyboards/epomaker/split70/linker/wireless/lowpower.c
@@ -1,0 +1,364 @@
+// Copyright 2024 Su (@isuua)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "quantum.h"
+#include "wireless.h"
+#include "usb_main.h"
+
+#ifndef LPWR_TIMEOUT
+#    define LPWR_TIMEOUT 300000 // 5min
+#endif
+
+#ifndef LPWR_PRESLEEP_DELAY
+#    define LPWR_PRESLEEP_DELAY 200
+#endif
+
+#ifndef LPWR_STOP_DELAY
+#    define LPWR_STOP_DELAY 200
+#endif
+
+#ifndef LPWR_WAKEUP_DELAY
+#    define LPWR_WAKEUP_DELAY 200
+#endif
+
+#ifdef TP_UART
+    #include "touch.h"
+#endif
+
+#ifdef GPIO_UART_ENABLE
+#include "iprint.h"
+#include <stdarg.h>
+#define DEBUG(fmt, ...) iprintf(fmt, ##__VA_ARGS__)
+#else
+#define DEBUG(fmt, ...)
+#endif
+
+static lpwr_state_t lpwr_state       = LPWR_NORMAL;
+static lpwr_mode_t lpwr_mode         = LPWR_MODE_TIMEOUT;
+static uint32_t lpwr_timeout_value   = LPWR_TIMEOUT;
+static uint32_t lpwr_timestamp       = 0x00;
+static lpwr_wakeupcd_t lpwr_wakeupcd = LPWR_WAKEUP_NONE;
+static bool manual_timeout           = false;
+
+static bool rgb_enable_bak = false;
+
+void last_matrix_activity_trigger(void);
+
+void lpwr_clock_enable(void);
+void lpwr_enter_stop(void);
+void lpwr_exti_init(void);
+void mcu_stop_mode(void);
+
+extern void matrix_init_pins(void);
+
+lpwr_state_t lpwr_get_state(void) {
+    return lpwr_state;
+}
+
+void lpwr_set_state(lpwr_state_t state) {
+    lpwr_state = state;
+}
+
+lpwr_mode_t lpwr_get_mode(void) {
+    return lpwr_mode;
+}
+
+void lpwr_set_mode(lpwr_mode_t mode) {
+    lpwr_mode = mode;
+}
+
+void lpwr_set_timeout_value(uint32_t timeout) {
+    lpwr_timeout_value = timeout;
+}
+
+uint32_t lpwr_timeout_value_read(void) {
+    return lpwr_timeout_value;
+}
+
+void lpwr_update_timestamp(void) {
+    lpwr_timestamp = sync_timer_read32();
+}
+
+uint32_t lpwr_timestamp_read(void) {
+    return lpwr_timestamp;
+}
+
+void lpwr_set_sleep_wakeupcd(lpwr_wakeupcd_t wakeupcd) {
+    lpwr_wakeupcd = wakeupcd;
+}
+
+lpwr_wakeupcd_t lpwr_get_sleep_wakeupcd(void) {
+    return lpwr_wakeupcd;
+}
+
+void lpwr_clock_enable(void) __attribute__((weak));
+void lpwr_clock_enable(void) {}
+
+void lpwr_exti_init(void) __attribute__((weak));
+void lpwr_exti_init(void) {}
+
+void mcu_stop_mode(void) __attribute__((weak));
+void mcu_stop_mode(void) {}
+
+void lpwr_enter_stop(void) {
+    chSysLock();
+    lpwr_exti_init();
+    chSysUnlock();
+
+    chSysDisable();
+    mcu_stop_mode();
+    lpwr_clock_enable();
+    matrix_init_pins();
+    chSysEnable();
+}
+
+void lpwr_set_timeout_manual(bool enable) {
+    manual_timeout = enable;
+}
+
+bool lpwr_get_timeout_manual(void) {
+    return manual_timeout;
+}
+
+// 2.4g mode, host state
+void md_receive_host_cb(bool resume) {
+
+    if (resume) {
+        if (lpwr_get_state() != LPWR_NORMAL) {
+            lpwr_update_timestamp();
+            lpwr_set_state(LPWR_WAKEUP);
+        }
+    }
+    /*
+     * Commenting out these lines might prevent a flicker but it also
+     * makes the keyboard become unresponsive after going to sleep. AI suggested
+     * several variations but they all either did not fix the flicker or caused
+     * the keyboard to lock up after sleep.
+     */
+    else {
+        if (lpwr_get_state() == LPWR_NORMAL) {
+            manual_timeout = true;
+        }
+    }
+}
+
+bool lpwr_is_allow_timeout_hook(void) __attribute__((weak));
+bool lpwr_is_allow_timeout_hook(void) {
+    return true;
+}
+
+bool lpwr_is_allow_timeout(void) __attribute__((weak));
+bool lpwr_is_allow_timeout(void) {
+    uint32_t timeout = lpwr_timeout_value_read();
+
+    if (lpwr_is_allow_timeout_hook() != true) {
+        manual_timeout = false;
+        return false;
+    }
+
+    if ((wireless_get_current_devs() == DEVS_USB) && (USB_DRIVER.state == USB_ACTIVE)) {
+        manual_timeout = false;
+        return false;
+    }
+
+    if (manual_timeout || (timeout && (last_input_activity_elapsed() >= timeout))) {
+        manual_timeout = false;
+        return true;
+    }
+
+    return false;
+}
+
+bool lpwr_is_allow_presleep_hook(void) __attribute__((weak));
+bool lpwr_is_allow_presleep_hook(void) {
+    extern bool charging_state;
+    if ((wireless_get_current_devs() == DEVS_USB) && (!charging_state)) {
+
+        if (USB_DRIVER.state != USB_STOP) {
+            usb_power_disconnect();
+            usbDisconnectBus(&USBD1);
+            usbStop(&USBD1);
+        }
+    }
+    return true;
+}
+
+bool lpwr_is_allow_presleep(void) __attribute__((weak));
+bool lpwr_is_allow_presleep(void) {
+    uint32_t delay = LPWR_PRESLEEP_DELAY;
+
+    if (lpwr_is_allow_presleep_hook() != true) {
+        return false;
+    }
+
+    if (!delay || (sync_timer_elapsed32(lpwr_timestamp_read()) >= delay)) {
+        return true;
+    }
+
+    return false;
+}
+
+bool lpwr_is_allow_stop_hook(void) __attribute__((weak));
+bool lpwr_is_allow_stop_hook(void) {
+    return true;
+}
+
+bool lpwr_is_allow_stop(void) __attribute__((weak));
+bool lpwr_is_allow_stop(void) {
+    uint32_t delay = LPWR_STOP_DELAY;
+
+    if (lpwr_is_allow_stop_hook() != true) {
+        return false;
+    }
+
+    if (!delay || (sync_timer_elapsed32(lpwr_timestamp_read()) >= delay)) {
+        return true;
+    }
+
+    return false;
+}
+
+bool lpwr_is_allow_wakeup_hook(void) __attribute__((weak));
+bool lpwr_is_allow_wakeup_hook(void) {
+    if (wireless_get_current_devs() == DEVS_USB && USB_DRIVER.state == USB_STOP)
+    {
+        usb_power_connect();
+        restart_usb_driver(&USBD1);
+        wireless_devs_change(!DEVS_USB, DEVS_USB, false);
+    }
+    return true;
+}
+
+bool lpwr_is_allow_wakeup(void) __attribute__((weak));
+bool lpwr_is_allow_wakeup(void) {
+    uint32_t delay = LPWR_WAKEUP_DELAY;
+
+    if (lpwr_is_allow_wakeup_hook() != true) {
+        return false;
+    }
+
+    if (!delay || (sync_timer_elapsed32(lpwr_timestamp_read()) >= delay)) {
+        return true;
+    }
+
+    return false;
+}
+
+void lpwr_presleep_hook(void) __attribute__((weak));
+void lpwr_presleep_hook(void) {}
+
+void lpwr_presleep_cb(void) __attribute__((weak));
+void lpwr_presleep_cb(void) {
+
+#if defined(RGB_MATRIX_ENABLE)
+    rgb_enable_bak = rgb_matrix_is_enabled();
+    rgb_matrix_disable_noeeprom();
+#elif defined(RGBLIGHT_ENABLE)
+    rgb_enable_bak = rgblight_is_enabled();
+    rgblight_disable_noeeprom();
+#else
+    rgb_enable_bak = false;
+#endif
+    suspend_power_down();
+    lpwr_presleep_hook();
+}
+
+void lpwr_stop_hook_pre(void) __attribute__((weak));
+void lpwr_stop_hook_pre(void) {}
+
+void lpwr_stop_hook_post(void) __attribute__((weak));
+void lpwr_stop_hook_post(void) {}
+
+void lpwr_stop_cb(void) __attribute__((weak));
+void lpwr_stop_cb(void) {
+
+    lpwr_set_sleep_wakeupcd(LPWR_WAKEUP_NONE);
+
+    lpwr_stop_hook_pre();
+    lpwr_enter_stop();
+
+    switch (lpwr_get_sleep_wakeupcd()) {
+        case LPWR_WAKEUP_UART: {
+            lpwr_set_state(LPWR_STOP);
+        } break;
+#ifdef TP_UART
+        case LPWR_WAKEUP_TP_PAD: {
+            // uint8_t data[3];
+            // touch_drivers_init(9600);
+            // if (touch_available()) touch_receive(data,3);
+            // DEBUG("data[0] = %d %d %dr\n",data[0],data[1],data[2]);
+            // if (data[0] == 0x66 && data[2] != 0x32 && data[2] == 0x65) {
+                // lpwr_set_state(LPWR_WAKEUP);
+            // }
+            // else{
+                // lpwr_set_state(LPWR_STOP);
+            // }
+
+            // if (wireless_get_current_devs() != DEVS_USB && *md_getp_state() == MD_STATE_CONNECTED){
+                lpwr_set_state(LPWR_WAKEUP);
+            // }
+
+        } break;
+#endif
+        default: {
+            lpwr_set_state(LPWR_WAKEUP);
+        } break;
+    }
+
+    lpwr_stop_hook_post();
+}
+
+void lpwr_wakeup_hook(void) __attribute__((weak));
+void lpwr_wakeup_hook(void) {}
+
+void lpwr_wakeup_cb(void) __attribute__((weak));
+void lpwr_wakeup_cb(void) {
+
+    if (rgb_enable_bak) {
+#if defined(RGB_MATRIX_ENABLE)
+        rgb_matrix_enable_noeeprom();
+#elif defined(RGBLIGHT_ENABLE)
+        rgblight_enable_noeeprom();
+#endif
+    }
+
+    suspend_wakeup_init();
+    lpwr_wakeup_hook();
+
+    last_matrix_activity_trigger();
+}
+
+void lpwr_task(void) __attribute__((weak));
+void lpwr_task(void) {
+
+    switch (lpwr_get_state()) {
+        case LPWR_NORMAL: {
+            if (lpwr_is_allow_timeout()) {
+                lpwr_update_timestamp();
+                lpwr_set_state(LPWR_PRESLEEP);
+            }
+        } break;
+        case LPWR_PRESLEEP: {
+            if (lpwr_is_allow_presleep()) {
+                lpwr_presleep_cb();
+                lpwr_update_timestamp();
+                lpwr_set_state(LPWR_STOP);
+            }
+        } break;
+        case LPWR_STOP: {
+            if (lpwr_is_allow_stop()) {
+                lpwr_update_timestamp();
+                lpwr_stop_cb();
+            }
+        } break;
+        case LPWR_WAKEUP: {
+            if (lpwr_is_allow_wakeup()) {
+                lpwr_wakeup_cb();
+                lpwr_update_timestamp();
+                lpwr_set_state(LPWR_NORMAL);
+            }
+        } break;
+        default:
+            break;
+    }
+}

--- a/keyboards/epomaker/split70/linker/wireless/lowpower.h
+++ b/keyboards/epomaker/split70/linker/wireless/lowpower.h
@@ -1,0 +1,42 @@
+// Copyright 2024 Su (@isuua)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+typedef enum {
+    LPWR_NORMAL = 0,
+    LPWR_PRESLEEP,
+    LPWR_STOP,
+    LPWR_WAKEUP,
+} lpwr_state_t;
+
+typedef enum {
+    LPWR_WAKEUP_NONE = 0,
+    LPWR_WAKEUP_MATRIX,
+    LPWR_WAKEUP_UART,
+    LPWR_WAKEUP_CABLE,
+    LPWR_WAKEUP_USB,
+    LPWR_WAKEUP_ONEKEY,
+    LPWR_WAKEUP_ENCODER,
+    LPWR_WAKEUP_SWITCH,
+#ifdef TP_UART
+    LPWR_WAKEUP_TP_PAD,
+#endif
+} lpwr_wakeupcd_t;
+
+typedef enum {
+    LPWR_MODE_TIMEOUT = 0,
+} lpwr_mode_t;
+
+lpwr_state_t lpwr_get_state(void);
+lpwr_mode_t lpwr_get_mode(void);
+uint32_t lpwr_timestamp_read(void);
+uint32_t lpwr_timeout_value_read(void);
+void lpwr_set_sleep_wakeupcd(lpwr_wakeupcd_t wakeupcd);
+lpwr_wakeupcd_t lpwr_get_sleep_wakeupcd(void);
+void lpwr_update_timestamp(void);
+void lpwr_set_timeout_manual(bool enable);
+bool lpwr_get_timeout_manual(void);
+void lpwr_set_state(lpwr_state_t state);
+void lpwr_set_mode(lpwr_mode_t mode);
+void lpwr_task(void);

--- a/keyboards/epomaker/split70/linker/wireless/lpwr_wb32.c
+++ b/keyboards/epomaker/split70/linker/wireless/lpwr_wb32.c
@@ -1,0 +1,308 @@
+// Copyright 2024 Su (@isuua)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "quantum.h"
+#include "wireless.h"
+#include "util.h"
+
+#ifndef LPWR_UART_WAKEUP_DISABLE
+#    include "uart.h"
+#endif
+
+#define MATRIX_SPLIT_IS_MASTER()       true
+
+#if defined(MATRIX_ROW_PINS_RIGHT) && defined(MATRIX_COL_PINS_RIGHT)
+    #define LP_MATRIX_ROWS                 MATRIX_ROWS/2
+    #    undef MATRIX_SPLIT_IS_MASTER
+    #    define MATRIX_SPLIT_IS_MASTER() is_keyboard_master()
+#else
+    #define LP_MATRIX_ROWS                 MATRIX_ROWS
+#endif
+
+#define LP_MATRIX_COLS                 MATRIX_COLS
+
+static ioline_t row_pins[LP_MATRIX_ROWS] = MATRIX_ROW_PINS;
+static ioline_t col_pins[LP_MATRIX_COLS] = MATRIX_COL_PINS;
+
+#if defined(MATRIX_ROW_PINS_RIGHT) && defined(MATRIX_COL_PINS_RIGHT)
+static ioline_t row_pins_r[LP_MATRIX_ROWS] = MATRIX_ROW_PINS_RIGHT;
+static ioline_t col_pins_r[LP_MATRIX_COLS] = MATRIX_COL_PINS_RIGHT;
+#endif
+
+#if PAL_USE_CALLBACKS != TRUE
+#    error PAL_USE_CALLBACKS must be set to TRUE!
+#endif
+
+#if !((DIODE_DIRECTION == ROW2COL) || (DIODE_DIRECTION == COL2ROW))
+#    error DIODE_DIRECTION must be one of COL2ROW or ROW2COL!
+#endif
+
+// clang-format off
+static const uint32_t pre_lp_code[] = {553863175u, 554459777u, 1208378049u, 4026624001u, 688390415u, 554227969u, 3204472833u, 1198571264u, 1073807360u, 1073808388u};
+#define PRE_LP() ((void (*)(void))((unsigned int)(pre_lp_code) | 0x01))()
+
+static const uint32_t post_lp_code[] = {553863177u, 554459777u, 1208509121u, 51443856u, 4026550535u, 1745485839u, 3489677954u, 536895496u, 673389632u, 1198578684u, 1073807360u, 536866816u, 1073808388u};
+#define POST_LP() ((void (*)(void))((unsigned int)(post_lp_code) | 0x01))()
+// clang-format on
+
+extern void __early_init(void);
+extern void matrix_init_pins(void);
+
+void palcallback_cb(uint8_t line) __attribute__((weak));
+void palcallback_cb(uint8_t line) {}
+
+void palcallback(void *arg) {
+    uint8_t line = (uint32_t)arg & 0xFF;
+
+    switch (line) {
+#ifndef LPWR_UART_WAKEUP_DISABLE
+        case PAL_PAD(UART_RX_PIN): {
+            lpwr_set_sleep_wakeupcd(LPWR_WAKEUP_UART);
+        } break;
+#endif
+        case(18):{
+            lpwr_set_sleep_wakeupcd(LPWR_WAKEUP_USB);
+        }break;
+        default: {
+            lpwr_set_sleep_wakeupcd(LPWR_WAKEUP_MATRIX);
+        } break;
+    }
+
+    palcallback_cb(line);
+
+    irqDeinit();
+    EXTI->PR = 0xFFFFFFFF;
+}
+
+void pal_events_init(void) {
+
+    for (uint8_t i = 0; i < 16; i++) {
+        _pal_events[i].cb  = palcallback;
+        _pal_events[i].arg = (void *)(uint32_t)i;
+    }
+}
+
+void lpwr_exti_init_hook(void) __attribute__((weak));
+void lpwr_exti_init_hook(void) {}
+
+void lpwr_exti_init(void) {
+
+    pal_events_init();
+
+#if DIODE_DIRECTION == ROW2COL
+    if (MATRIX_SPLIT_IS_MASTER()){
+    for (uint8_t i = 0; i < ARRAY_SIZE(col_pins); i++) {
+        if (col_pins[i] != NO_PIN) {
+            gpio_set_pin_output_open_drain(col_pins[i]);
+            gpio_write_pin_low(col_pins[i]);
+        }
+    }
+
+    for (uint8_t i = 0; i < ARRAY_SIZE(row_pins); i++) {
+        if (row_pins[i] != NO_PIN) {
+            gpio_set_pin_input_high(row_pins[i]);
+            waitInputPinDelay();
+            palEnableLineEvent(row_pins[i], PAL_EVENT_MODE_FALLING_EDGE);
+        }
+    }
+    } else {
+        for (uint8_t i = 0; i < ARRAY_SIZE(col_pins_r); i++) {
+            if (col_pins_r[i] != NO_PIN) {
+                gpio_set_pin_output_open_drain(col_pins_r[i]);
+                gpio_write_pin_low(col_pins_r[i]);
+            }
+        }
+
+        for (uint8_t i = 0; i < ARRAY_SIZE(row_pins_r); i++) {
+            if (row_pins_r[i] != NO_PIN) {
+                gpio_set_pin_input_high(row_pins_r[i]);
+                waitInputPinDelay();
+                palEnableLineEvent(row_pins_r[i], PAL_EVENT_MODE_FALLING_EDGE);
+            }
+        }
+    }
+#elif DIODE_DIRECTION == COL2ROW
+    for (uint8_t i = 0; i < ARRAY_SIZE(row_pins); i++) {
+        if (row_pins[i] != NO_PIN) {
+            gpio_set_pin_output_open_drain(row_pins[i]);
+            gpio_write_pin_low(row_pins[i]);
+        }
+    }
+
+    for (uint8_t i = 0; i < ARRAY_SIZE(col_pins); i++) {
+        if (col_pins[i] != NO_PIN) {
+            gpio_set_pin_input_high(col_pins[i]);
+            waitInputPinDelay();
+            palEnableLineEvent(col_pins[i], PAL_EVENT_MODE_FALLING_EDGE);
+        }
+    }
+#endif
+
+// Disabled UART_RX_PIN wake - prevents wireless module communication from waking device
+// This fixes the issue where the 30-minute deep sleep command wakes the device
+// #ifndef LPWR_UART_WAKEUP_DISABLE
+//     extern bool lower_sleep;
+//     if (!lower_sleep){
+//     setPinInput(UART_RX_PIN);
+//     waitInputPinDelay();
+//     palEnableLineEvent(UART_RX_PIN, PAL_EVENT_MODE_BOTH_EDGES);
+//     }
+// #endif
+
+#ifdef SPLIT_KEYBOARD
+    gpio_set_pin_input(SERIAL_USART_RX_PIN);
+    waitInputPinDelay();
+    palEnableLineEvent(SERIAL_USART_RX_PIN, PAL_EVENT_MODE_BOTH_EDGES);
+#endif
+
+    palEnableLineEvent(A12,PAL_EVENT_MODE_RISING_EDGE);
+    nvicEnableVector(USBP_WKUP_IRQn,6);
+    lpwr_exti_init_hook();
+
+    /* IRQ subsystem initialization.*/
+    irqInit();
+}
+
+void lpwr_clock_enable_user(void) __attribute__((weak));
+void lpwr_clock_enable_user(void) {}
+
+void lpwr_clock_enable(void) {
+
+    __early_init();
+
+    PWR->ANAKEY1 = 0x03;
+    PWR->ANAKEY2 = 0x0C;
+    ANCTL->USBPCR &= ~(ANCTL_USBPCR_DMSTEN | ANCTL_USBPCR_DPSTEN);
+    /* Locks write to ANCTL registers */
+    PWR->ANAKEY1 = 0x00;
+    PWR->ANAKEY2 = 0x00;
+
+    /* Enable SFM clock */
+    RCC->AHBENR1 |= RCC_AHBENR1_CRCSFMEN;
+
+    /* Enable USB peripheral clock */
+    RCC->AHBENR1 |= RCC_AHBENR1_USBEN;
+
+    /* Configure USB FIFO clock source */
+    RCC->USBFIFOCLKSRC = RCC_USBFIFOCLKSRC_USBCLK;
+
+    /* Enable USB FIFO clock */
+    RCC->USBFIFOCLKENR = RCC_USBFIFOCLKENR_CLKEN;
+
+    /* Configure and enable USBCLK */
+#        if (WB32_USBPRE == WB32_USBPRE_DIV1P5)
+    RCC->USBCLKENR = RCC_USBCLKENR_CLKEN;
+    RCC->USBPRE    = RCC_USBPRE_SRCEN;
+    RCC->USBPRE |= RCC_USBPRE_RATIO_1_5;
+    RCC->USBPRE |= RCC_USBPRE_DIVEN;
+#        elif (WB32_USBPRE == WB32_USBPRE_DIV1)
+    RCC->USBCLKENR = RCC_USBCLKENR_CLKEN;
+    RCC->USBPRE    = RCC_USBPRE_SRCEN;
+    RCC->USBPRE |= 0x00;
+#        elif (WB32_USBPRE == WB32_USBPRE_DIV2)
+    RCC->USBCLKENR = RCC_USBCLKENR_CLKEN;
+    RCC->USBPRE    = RCC_USBPRE_SRCEN;
+    RCC->USBPRE |= RCC_USBPRE_RATIO_2;
+    RCC->USBPRE |= RCC_USBPRE_DIVEN;
+#        elif (WB32_USBPRE == WB32_USBPRE_DIV3)
+    RCC->USBCLKENR = RCC_USBCLKENR_CLKEN;
+    RCC->USBPRE    = RCC_USBPRE_SRCEN;
+    RCC->USBPRE |= RCC_USBPRE_RATIO_3;
+    RCC->USBPRE |= RCC_USBPRE_DIVEN;
+#endif
+    rccEnableEXTI();
+
+#if WB32_SERIAL_USE_UART1
+    rccEnableUART1();
+#endif
+#if WB32_SERIAL_USE_UART2
+    rccEnableUART2();
+#endif
+#if WB32_SERIAL_USE_UART3
+    rccEnableUART3();
+#endif
+#if WB32_SPI_USE_QSPI
+    rccEnableQSPI();
+#endif
+#if WB32_SPI_USE_SPIM2
+    rccEnableSPIM2();
+#endif
+#if WB32_I2C_USE_I2C1
+    rccEnableI2C1();
+#endif
+#if WB32_I2C_USE_I2C2
+    rccEnableI2C2();
+#endif
+
+#if WB32_GPT_USE_TIM1 || WB32_ICU_USE_TIM1 || WB32_PWM_USE_TIM1
+    rccEnableTIM1();
+#endif
+#if WB32_ST_USE_TIM2 || WB32_GPT_USE_TIM2 || WB32_ICU_USE_TIM2 || WB32_PWM_USE_TIM2
+    rccEnableTIM2();
+#endif
+#if WB32_ST_USE_TIM3 || WB32_GPT_USE_TIM3 || WB32_ICU_USE_TIM3 || WB32_PWM_USE_TIM3
+    rccEnableTIM3();
+#endif
+#if WB32_ST_USE_TIM4 || WB32_GPT_USE_TIM4 || WB32_ICU_USE_TIM4 || WB32_PWM_USE_TIM4
+    rccEnableTIM4();
+#endif
+
+#ifndef LPWR_UART_WAKEUP_DISABLE
+    palSetLineMode(UART_RX_PIN, PAL_MODE_ALTERNATE(UART_RX_PAL_MODE) | PAL_OUTPUT_TYPE_PUSHPULL | PAL_OUTPUT_SPEED_HIGHEST);
+#endif
+
+#ifdef SPLIT_KEYBOARD
+    palSetLineMode(SERIAL_USART_TX_PIN, PAL_MODE_ALTERNATE(SERIAL_USART_TX_PAL_MODE) | PAL_OUTPUT_TYPE_PUSHPULL | PAL_OUTPUT_SPEED_HIGHEST);
+    palSetLineMode(SERIAL_USART_RX_PIN, PAL_MODE_ALTERNATE(SERIAL_USART_RX_PAL_MODE) | PAL_OUTPUT_TYPE_PUSHPULL | PAL_OUTPUT_SPEED_HIGHEST);
+#endif
+
+    lpwr_clock_enable_user();
+}
+
+void wb32_stop_mode(void) {
+
+    SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
+
+    /* Prevent the chip from being unable to enter stop mode due to pending interrupts */
+#if 1
+    EXTI->PR = 0x7FFFF;
+    for (uint8_t i = 0; i < 8; i++) {
+        for (uint8_t j = 0; j < 32; j++) {
+             /*
+             * Recommended by AI to prevent instant/false wakeups
+             */
+            if (NVIC->ISPR[i] & (0x01UL << j)) {
+                NVIC->ICPR[i] = (0x01UL << j);
+            }
+        }
+    }
+    SCB->ICSR |= SCB_ICSR_PENDSTCLR_Msk; // Clear Systick IRQ Pending
+#endif
+
+    /* Clear all bits except DBP and FCLKSD bit */
+    PWR->CR0 &= 0x09U;
+
+    // STOP LP4 MODE S32KON
+    PWR->CR0 |= 0x3B004U;
+    PWR->CFGR = 0x3B3;
+
+    PRE_LP();
+
+    /* Set SLEEPDEEP bit of Cortex System Control Register */
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+
+    /* Request Wait For Interrupt */
+    __WFI();
+
+    POST_LP();
+
+    /* Clear SLEEPDEEP bit of Cortex System Control Register */
+    SCB->SCR &= (~SCB_SCR_SLEEPDEEP_Msk);
+
+    SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
+}
+
+void mcu_stop_mode(void) {
+
+    wb32_stop_mode();
+}

--- a/keyboards/epomaker/split70/linker/wireless/md_raw.c
+++ b/keyboards/epomaker/split70/linker/wireless/md_raw.c
@@ -1,0 +1,30 @@
+// Copyright 2024 QMK
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#if RAW_ENABLE
+
+#    include "quantum.h"
+#    include "wireless.h"
+#    include "usb_endpoints.h"
+#    include "usb_main.h"
+
+void replaced_hid_send(uint8_t *data, uint8_t length) {
+
+    if (length != RAW_EPSIZE) {
+        return;
+    }
+
+    if (get_transport() == TRANSPORT_USB) {
+        send_report(USB_ENDPOINT_IN_RAW, data, length);
+    } else {
+        md_send_raw(data, length);
+    }
+}
+
+void md_receive_raw_cb(uint8_t *data, uint8_t length) {
+    void raw_hid_receive(uint8_t * data, uint8_t length);
+
+    raw_hid_receive(data, length);
+}
+
+#endif

--- a/keyboards/epomaker/split70/linker/wireless/module.c
+++ b/keyboards/epomaker/split70/linker/wireless/module.c
@@ -1,0 +1,553 @@
+// Copyright 2024 Su (@isuua)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "quantum.h"
+#include "module.h"
+#include "smsg.h"
+#include "uart.h"
+
+#ifndef MD_BAUD_RATE
+#    define MD_BAUD_RATE 115200
+#endif
+
+#ifndef MD_SNED_PKT_TIMEOUT
+#    define MD_SNED_PKT_TIMEOUT 10
+#endif
+
+#ifndef MD_SEND_PKT_RETRY
+#    define MD_SEND_PKT_RETRY 40
+#endif
+
+#ifndef MD_SEND_PKT_PAYLOAD_MAX
+#    define MD_SEND_PKT_PAYLOAD_MAX ((MD_RAW_SIZE) + 4)
+#endif
+
+#ifndef MD_BT1_NAME
+#    define MD_BT1_NAME PRODUCT " BT1"
+#endif
+
+#ifndef MD_BT2_NAME
+#    define MD_BT2_NAME PRODUCT " BT2"
+#endif
+
+#ifndef MD_BT3_NAME
+#    define MD_BT3_NAME PRODUCT " BT3"
+#endif
+
+#ifndef MD_BT4_NAME
+#    define MD_BT4_NAME PRODUCT " BT4"
+#endif
+
+#ifndef MD_BT5_NAME
+#    define MD_BT5_NAME PRODUCT " BT5"
+#endif
+
+#ifndef MD_DONGLE_MANUFACTURER
+#    define MD_DONGLE_MANUFACTURER MANUFACTURER
+#endif
+
+#ifndef MD_DONGLE_PRODUCT
+#    define MD_DONGLE_PRODUCT PRODUCT " Dongle"
+#endif
+
+#ifndef MD_RAW_SIZE
+#    define MD_RAW_SIZE 32
+#endif
+
+#define USBCONCAT(a, b) a##b
+#define USBSTR(s) USBCONCAT(L, s)
+
+typedef struct
+{
+    uint8_t state;
+    uint8_t indicator;
+    uint8_t version;
+    uint8_t bat;
+} md_info_t;
+
+static uint8_t md_pkt_payload[MD_SEND_PKT_PAYLOAD_MAX] = {0};
+static uint8_t md_rev_payload[MD_SEND_PKT_PAYLOAD_MAX] = {0};
+static uint8_t md_raw_payload[MD_RAW_SIZE]             = {0};
+
+static md_info_t md_info = {
+    .bat       = 100,
+    .indicator = 0,
+    .version   = 0,
+    .state     = MD_STATE_NONE,
+};
+
+static void md_send_ack(void) {
+
+    uint8_t sdata[0x03] = {0x61, 0x0D, 0x0A};
+    uart_transmit(sdata, sizeof(sdata));
+}
+
+static bool md_check_sum(const uint8_t *data, uint32_t length) {
+    uint8_t sum = 0;
+
+    for (uint32_t i = 0; i < (length - 1); i++) {
+        sum += data[i];
+    }
+
+    return sum == data[length - 1];
+}
+
+static void md_calc_check_sum(uint8_t *data, uint32_t length) {
+    uint8_t sum = 0;
+
+    for (uint32_t i = 0; i < length; i++) {
+        sum += data[i];
+    }
+
+    data[length] = sum;
+}
+
+bool md_receive_process_user(uint8_t *pdata, uint8_t len) __attribute__((weak));
+bool md_receive_process_user(uint8_t *pdata, uint8_t len) {
+    return true;
+}
+
+bool md_receive_process_kb(uint8_t *pdata, uint8_t len) __attribute__((weak));
+bool md_receive_process_kb(uint8_t *pdata, uint8_t len) {
+    return md_receive_process_user(pdata, len);
+}
+
+void md_receive_raw_cb(uint8_t *pdata, uint8_t len) __attribute__((weak));
+void md_receive_raw_cb(uint8_t *pdata, uint8_t len) {}
+
+void md_receive_host_cb(bool resume) __attribute__((weak));
+void md_receive_host_cb(bool resume) {}
+
+static void md_receive_msg_task(void) {
+    static uint32_t data_count = 0x00;
+    static uint8_t data_remain = 0x00;
+
+    while (uart_available()) {
+        uint8_t data = uart_read();
+
+        switch (data_count) {
+            case 0: { // cmd
+                switch (data) {
+                    case MD_REV_CMD_RAW:
+                    case MD_REV_CMD_INDICATOR:
+                    case MD_REV_CMD_DEVCTRL:
+                    case MD_REV_CMD_BATVOL:
+                    case MD_REV_CMD_MD_FW_VERSION:
+                    case MD_REV_CMD_HOST_STATE:
+                    case 0x61: {
+                        md_rev_payload[data_count++] = data;
+                        data_remain                  = 2;
+                    } break;
+                    default: {
+                        data_count = 0;
+                    } break;
+                }
+                continue;
+            } break;
+            case 1: {
+                md_rev_payload[data_count++] = data;
+                data_remain--;
+                continue;
+            } break;
+            case 2: {
+                // ACK
+                if ((md_rev_payload[0] == 0x61) && (md_rev_payload[1] == 0x0D) && (data == 0x0A)) {
+                    if (smsg_get_state() == smsg_state_busy) {
+                        smsg_set_state(smsg_state_replied);
+                    }
+                    data_count = 0;
+                    return;
+                }
+
+                // raw data
+                if ((md_rev_payload[0] == MD_REV_CMD_RAW) && (md_rev_payload[1] == MD_REV_CMD_RAW_OUT)) {
+                    md_rev_payload[data_count++] = data;
+                    data_remain                  = data + 1;
+                    continue;
+                }
+            }
+            default: {
+                md_rev_payload[data_count++] = data;
+                data_remain--;
+
+                if (data_remain) {
+                    continue;
+                }
+            } break;
+        }
+
+        if (md_check_sum(md_rev_payload, data_count)) {
+            md_send_ack();
+
+            if (md_receive_process_kb(md_rev_payload, data_count) != true) {
+                return;
+            }
+
+            switch (md_rev_payload[0]) {
+                case MD_REV_CMD_RAW: {
+                    uint8_t *pdata;
+                    uint8_t len;
+
+                    len   = md_rev_payload[2];
+                    pdata = &md_rev_payload[3];
+
+                    if (len == sizeof(md_raw_payload)) {
+                        memcpy(md_raw_payload, pdata, len);
+                        md_receive_raw_cb(md_raw_payload, len);
+                    }
+                } break;
+                case MD_REV_CMD_INDICATOR: {
+                    md_info.indicator = md_rev_payload[1];
+                } break;
+                case MD_REV_CMD_DEVCTRL: {
+                    switch (md_rev_payload[1]) {
+                        case MD_REV_CMD_DEVCTRL_PAIRING: {
+                            md_info.state = MD_STATE_PAIRING;
+                        } break;
+                        case MD_REV_CMD_DEVCTRL_CONNECTED: {
+                            md_info.state = MD_STATE_CONNECTED;
+                        } break;
+                        case MD_REV_CMD_DEVCTRL_DISCONNECTED: {
+                            md_info.state = MD_STATE_DISCONNECTED;
+                        } break;
+                        case MD_REV_CMD_DEVCTRL_REJECT: {
+                            md_info.state = MD_STATE_REJECT;
+                        } break;
+                        default:
+                            break;
+                    }
+                } break;
+                case MD_REV_CMD_BATVOL: {
+                    md_info.bat = md_rev_payload[1];
+                } break;
+                case MD_REV_CMD_MD_FW_VERSION: {
+                    md_info.version = md_rev_payload[1];
+                } break;
+                case MD_REV_CMD_HOST_STATE: {
+                    md_receive_host_cb(md_rev_payload[1] == MD_REV_CMD_HOST_STATE_RESUME);
+                } break;
+                default:
+                    break;
+            }
+        }
+        data_count = 0;
+    }
+}
+
+static void md_send_pkt_task(void) {
+    static uint32_t smsg_timer = 0x00;
+    static uint8_t smsg_retry  = 0;
+
+    switch (smsg_get_state()) {
+        case smsg_state_busy: {
+            if (sync_timer_elapsed32(smsg_timer) > (MD_SNED_PKT_TIMEOUT)) {
+                smsg_retry = 0;
+                smsg_set_state(smsg_state_retry);
+            }
+        } break;
+        case smsg_state_retry: {
+            if (++smsg_retry > MD_SEND_PKT_RETRY) {
+                smsg_retry = 0;
+                smsg_pop();
+            }
+            smsg_set_state(smsg_state_free);
+        } break;
+        case smsg_state_replied: {
+            smsg_pop();
+            smsg_set_state(smsg_state_free);
+        } // break;
+        case smsg_state_free: {
+            uint32_t size = smsg_peek(md_pkt_payload);
+            if (size) {
+                md_send_pkt(md_pkt_payload, size);
+                smsg_timer = sync_timer_read32();
+                smsg_set_state(smsg_state_busy);
+            }
+        } break;
+        default:
+            break;
+    }
+}
+
+void md_init(void) {
+
+    uart_init(MD_BAUD_RATE);
+    smsg_init();
+
+    memset(md_pkt_payload, 0, sizeof(md_pkt_payload));
+}
+
+void md_main_task(void) {
+
+    md_send_pkt_task();
+    md_receive_msg_task();
+}
+
+uint8_t *md_getp_state(void) {
+
+    return &md_info.state;
+}
+
+uint8_t *md_getp_bat(void) {
+
+    return &md_info.bat;
+}
+
+uint8_t *md_getp_indicator(void) {
+
+    return &md_info.indicator;
+}
+
+uint8_t md_get_version(void) {
+
+    return md_info.version;
+}
+
+void md_send_pkt(uint8_t *data, uint32_t len) {
+
+    if (!data || !len) {
+        return;
+    }
+
+    // send
+    uart_transmit(data, len);
+}
+
+void md_send_kb(uint8_t *data) {
+    uint8_t sdata[MD_SND_CMD_KB_LEN + 2] = {0x00};
+
+    sdata[0] = MD_SND_CMD_SEND_KB;
+    memcpy(&sdata[1], data, sizeof(sdata) - 2);
+    md_calc_check_sum(sdata, sizeof(sdata) - 1);
+    smsg_push(sdata, sizeof(sdata));
+}
+
+void md_send_nkro(uint8_t *data) {
+    uint8_t sdata[MD_SND_CMD_NKRO_LEN + 2] = {0x00};
+
+    sdata[0] = MD_SND_CMD_SEND_NKRO;
+    memcpy(&sdata[1], data, sizeof(sdata) - 2);
+    md_calc_check_sum(sdata, sizeof(sdata) - 1);
+    smsg_push(sdata, sizeof(sdata));
+}
+
+void md_send_consumer(uint8_t *data) {
+    uint8_t sdata[MD_SND_CMD_CONSUMER_LEN + 2] = {0x00};
+
+    sdata[0] = MD_SND_CMD_SEND_CONSUMER;
+    memcpy(&sdata[1], data, sizeof(sdata) - 2);
+    md_calc_check_sum(sdata, sizeof(sdata) - 1);
+    smsg_push(sdata, sizeof(sdata));
+}
+
+void md_send_devctrl_bat(uint8_t cmd) {
+    uint8_t sdata[3] = {0x00};
+
+    sdata[0] = MD_SND_CMD_DEVCTRL_BAT;
+    memcpy(&sdata[1], &cmd, sizeof(sdata) - 2);
+    md_calc_check_sum(sdata, sizeof(sdata) - 1);
+    smsg_push(sdata, sizeof(sdata));
+}
+
+void md_send_system(uint8_t *data) {
+    uint8_t sdata[MD_SND_CMD_SYSTEM_LEN + 2] = {0x00};
+
+    sdata[0] = MD_SND_CMD_SEND_SYSTEM;
+    memcpy(&sdata[1], data, sizeof(sdata) - 2);
+    md_calc_check_sum(sdata, sizeof(sdata) - 1);
+    smsg_push(sdata, sizeof(sdata));
+}
+
+void md_send_fn(uint8_t *data) {
+    uint8_t sdata[MD_SND_CMD_FN_LEN + 2] = {0x00};
+
+    sdata[0] = MD_SND_CMD_SEND_FN;
+    memcpy(&sdata[1], data, sizeof(sdata) - 2);
+    md_calc_check_sum(sdata, sizeof(sdata) - 1);
+    smsg_push(sdata, sizeof(sdata));
+}
+
+void md_send_mouse(uint8_t *data) {
+    uint8_t sdata[MD_SND_CMD_MOUSE_LEN + 2] = {0x00};
+
+    sdata[0] = MD_SND_CMD_SEND_MOUSE;
+    memcpy(&sdata[1], data, sizeof(sdata) - 2);
+    md_calc_check_sum(sdata, sizeof(sdata) - 1);
+    smsg_push(sdata, sizeof(sdata));
+}
+
+void md_send_devinfo(const char *name) {
+    uint8_t sdata[MD_SND_CMD_DEVINFO_LEN + 3] = {0x00};
+    uint8_t infolen                           = strlen((const char *)name);
+
+    if (infolen > MD_SND_CMD_DEVINFO_LEN) {
+        return;
+    }
+
+    sdata[0] = MD_SND_CMD_SEND_DEVINFO;
+    sdata[1] = infolen;
+
+    memcpy(&sdata[2], name, infolen);
+    md_calc_check_sum(sdata, infolen + 2);
+    smsg_push(sdata, sizeof(sdata));
+}
+
+void md_send_devctrl(uint8_t cmd) {
+    uint8_t sdata[3] = {0x00};
+
+    sdata[0] = MD_SND_CMD_DEVCTRL;
+    memcpy(&sdata[1], &cmd, sizeof(sdata) - 2);
+    md_calc_check_sum(sdata, sizeof(sdata) - 1);
+    smsg_push(sdata, sizeof(sdata));
+}
+
+void md_rf_send_carrier(uint8_t channel, uint8_t tx_power, uint8_t phy) {
+    uint8_t sdata[5] = {0x00};
+
+    sdata[0] = CONTINUE;
+    sdata[1] = channel;
+    sdata[2] = tx_power;
+    sdata[3] = phy;
+    md_calc_check_sum(sdata, sizeof(sdata) - 1);
+    // sdata[4] = sdata[0] + sdata[1] - sdata[3];
+    smsg_push(sdata, sizeof(sdata));
+}
+
+void md_rf_send_stop(void) {
+    uint8_t sdata[3] = {0xB4, 0x00, 0xB4};
+
+    smsg_push(sdata, sizeof(sdata));
+}
+
+void md_send_manufacturer(char *str, uint8_t len) {
+    uint8_t sdata[MD_SND_CMD_MANUFACTURER_LEN + 3] = {0x00};
+
+    if (len > MD_SND_CMD_MANUFACTURER_LEN) {
+        return;
+    }
+
+    sdata[0] = MD_SND_CMD_MANUFACTURER;
+    sdata[1] = len;
+    memcpy(&sdata[2], str, len);
+    md_calc_check_sum(sdata, len + 2);
+    smsg_push(sdata, len + 3);
+}
+
+void md_send_product(char *str, uint8_t len) {
+    uint8_t sdata[MD_SND_CMD_PRODUCT_LEN + 3] = {0x00};
+
+    if (len > MD_SND_CMD_PRODUCT_LEN) {
+        return;
+    }
+
+    sdata[0] = MD_SND_CMD_PRODUCT;
+    sdata[1] = len;
+    memcpy(&sdata[2], str, len);
+    md_calc_check_sum(sdata, len + 2);
+    smsg_push(sdata, len + 3);
+}
+
+void md_send_vpid(uint16_t vid, uint16_t pid) {
+    uint8_t sdata[4 + 2] = {0x00};
+    uint32_t vpid;
+
+    vpid = (pid << 16) | vid;
+
+    sdata[0] = MD_SND_CMD_VPID;
+    memcpy(&sdata[1], &vpid, sizeof(vpid));
+    md_calc_check_sum(sdata, sizeof(sdata) - 1);
+    smsg_push(sdata, sizeof(sdata));
+}
+
+void md_send_raw(uint8_t *data, uint8_t length) {
+    uint8_t sdata[MD_RAW_SIZE + 4] = {0x00};
+
+    if (length != MD_RAW_SIZE) {
+        return;
+    }
+
+    sdata[0] = MD_SND_CMD_RAW;
+    sdata[1] = MD_SND_CMD_RAW_IN;
+    sdata[2] = length;
+    memcpy(&sdata[3], data, length);
+    md_calc_check_sum(sdata, sizeof(sdata) - 1);
+    smsg_push(sdata, sizeof(sdata));
+}
+
+void md_devs_change(uint8_t devs, bool reset) __attribute__((weak));
+void md_devs_change(uint8_t devs, bool reset) {
+
+    switch (devs) {
+        case DEVS_USB: {
+            md_send_devctrl(MD_SND_CMD_DEVCTRL_USB);
+        } break;
+        case DEVS_2G4: {
+            md_send_devctrl(MD_SND_CMD_DEVCTRL_2G4);
+            if (reset) {
+                // if (md_get_version() < 48) {
+                //     md_send_manufacturer(MD_DONGLE_MANUFACTURER, strlen(MD_DONGLE_MANUFACTURER));
+                //     md_send_product(MD_DONGLE_PRODUCT, strlen(MD_DONGLE_PRODUCT));
+                // } else { // Add Unicode character support starting from v48.
+                    md_send_manufacturer((char *)USBSTR(MD_DONGLE_MANUFACTURER), sizeof(USBSTR(MD_DONGLE_MANUFACTURER)));
+                    md_send_product((char *)USBSTR(MD_DONGLE_PRODUCT), sizeof(USBSTR(MD_DONGLE_PRODUCT)));
+                // }
+                md_send_vpid(VENDOR_ID, PRODUCT_ID);
+                md_send_devctrl(MD_SND_CMD_DEVCTRL_CLEAN);
+                md_send_devctrl(MD_SND_CMD_DEVCTRL_PAIR);
+            }
+        } break;
+        case DEVS_BT1: {
+            md_send_devctrl(MD_SND_CMD_DEVCTRL_BT1);
+            if (reset) {
+                md_send_devctrl(MD_SND_CMD_DEVCTRL_CLEAN);
+                md_send_devinfo(MD_BT1_NAME);
+                md_send_devctrl(MD_SND_CMD_DEVCTRL_PAIR);
+            }
+        } break;
+        case DEVS_BT2: {
+            md_send_devctrl(MD_SND_CMD_DEVCTRL_BT2);
+            if (reset) {
+                md_send_devctrl(MD_SND_CMD_DEVCTRL_CLEAN);
+                md_send_devinfo(MD_BT2_NAME);
+                md_send_devctrl(MD_SND_CMD_DEVCTRL_PAIR);
+            }
+        } break;
+        case DEVS_BT3: {
+            md_send_devctrl(MD_SND_CMD_DEVCTRL_BT3);
+            if (reset) {
+                md_send_devctrl(MD_SND_CMD_DEVCTRL_CLEAN);
+                md_send_devinfo(MD_BT3_NAME);
+                md_send_devctrl(MD_SND_CMD_DEVCTRL_PAIR);
+            }
+        } break;
+        case DEVS_BT4: {
+            md_send_devctrl(MD_SND_CMD_DEVCTRL_BT4);
+            if (reset) {
+                md_send_devctrl(MD_SND_CMD_DEVCTRL_CLEAN);
+                md_send_devinfo(MD_BT4_NAME);
+                md_send_devctrl(MD_SND_CMD_DEVCTRL_PAIR);
+            }
+        } break;
+        case DEVS_BT5: {
+            md_send_devctrl(MD_SND_CMD_DEVCTRL_BT5);
+            if (reset) {
+                md_send_devctrl(MD_SND_CMD_DEVCTRL_CLEAN);
+                md_send_devinfo(MD_BT5_NAME);
+                md_send_devctrl(MD_SND_CMD_DEVCTRL_PAIR);
+            }
+        } break;
+        default:
+            break;
+    }
+}
+
+bool md_inquire_bat(void) {
+
+    if (smsg_is_busy()) {
+        return false;
+    }
+
+    md_send_devctrl(MD_SND_CMD_DEVCTRL_INQVOL);
+
+    return true;
+}

--- a/keyboards/epomaker/split70/linker/wireless/module.h
+++ b/keyboards/epomaker/split70/linker/wireless/module.h
@@ -1,0 +1,134 @@
+// Copyright 2024 Su (@isuua)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+// device index
+enum {
+    DEVS_USB = 0,
+    DEVS_BT1,
+    DEVS_BT2,
+    DEVS_BT3,
+    DEVS_BT4,
+    DEVS_BT5,
+    DEVS_2G4,
+};
+
+enum {
+    MD_STATE_NONE = 0,
+    MD_STATE_PAIRING,
+    MD_STATE_CONNECTED,
+    MD_STATE_DISCONNECTED,
+    MD_STATE_REJECT,
+};
+
+enum {
+    MD_SND_CMD_KB_LEN           = 8,
+    MD_SND_CMD_NKRO_LEN         = 14,
+    MD_SND_CMD_CONSUMER_LEN     = 2,
+    MD_SND_CMD_SYSTEM_LEN       = 1,
+    MD_SND_CMD_FN_LEN           = 1,
+    MD_SND_CMD_MOUSE_LEN        = 5,
+    MD_SND_CMD_DEVINFO_LEN      = 18,
+    MD_SND_CMD_MANUFACTURER_LEN = 46,
+    MD_SND_CMD_PRODUCT_LEN      = 46,
+};
+
+enum {
+    /* send report */
+    MD_SND_CMD_SEND_KB       = 0xA1,
+    MD_SND_CMD_SEND_NKRO     = 0xA2,
+    MD_SND_CMD_SEND_CONSUMER = 0xA3,
+    MD_SND_CMD_SEND_SYSTEM   = 0xA4,
+    MD_SND_CMD_SEND_FN       = 0xA5,
+    MD_SND_CMD_SEND_MOUSE    = 0xA8,
+    MD_SND_CMD_SEND_DEVINFO  = 0xA9,
+    /* Dongle */
+    MD_SND_CMD_MANUFACTURER = 0xAB,
+    MD_SND_CMD_PRODUCT      = 0xAC,
+    MD_SND_CMD_VPID         = 0xAD,
+    MD_SND_CMD_RAW          = 0xAF,
+    MD_SND_CMD_RAW_IN       = 0x61,
+    /* device ctrl */
+    MD_SND_CMD_DEVCTRL                    = 0xA6,
+    MD_SND_CMD_DEVCTRL_BAT                = 0xA7,
+    MD_SND_CMD_DEVCTRL_USB                = 0x11,
+    MD_SND_CMD_DEVCTRL_2G4                = 0x30,
+    MD_SND_CMD_DEVCTRL_BT1                = 0x31,
+    MD_SND_CMD_DEVCTRL_BT2                = 0x32,
+    MD_SND_CMD_DEVCTRL_BT3                = 0x33,
+    MD_SND_CMD_DEVCTRL_BT4                = 0x34,
+    MD_SND_CMD_DEVCTRL_BT5                = 0x35,
+    MD_SND_CMD_DEVCTRL_PAIR               = 0x51,
+    MD_SND_CMD_DEVCTRL_CLEAN              = 0x52,
+    MD_SND_CMD_DEVCTRL_INQVOL             = 0x53,
+    MD_SND_CMD_DEVCTRL_SLEEP_INSTANT      = 0x54, // reserved
+    MD_SND_CMD_DEVCTRL_SLEEP_BT_EN        = 0x55, // timeout 30min enable in BT mode
+    MD_SND_CMD_DEVCTRL_SLEEP_BT_DIS       = 0x56, // timeout 30min disable in BT mode
+    MD_SND_CMD_DEVCTRL_SLEEP_2G4_EN       = 0x57, // timeout 30min enable in 2.4G mode
+    MD_SND_CMD_DEVCTRL_SLEEP_2G4_DIS      = 0x58, // timeout 30min enable in 2.4G mode
+    MD_SND_CMD_DEVCTRL_RSV_DEBUG          = 0x60, // reserved
+    MD_SND_CMD_DEVCTRL_RSV_SLEEP          = 0x61, // reserved
+    MD_SND_CMD_DEVCTRL_FORCED_PAIRING_BT  = 0x62, // forced pairing, to be used in a factory environment.
+    MD_SND_CMD_DEVCTRL_FORCED_PAIRING_2G4 = 0x63, // forced pairing, to be used in a factory environment.
+    MD_SND_CMD_DEVCTRL_CHARGING           = 0x64, // battery power control.
+    MD_SND_CMD_DEVCTRL_CHARGING_STOP      = 0x65, // battery power control.
+    MD_SND_CMD_DEVCTRL_CHARGING_DONE      = 0x66, // battery power control.
+    MD_SND_CMD_DEVCTRL_FW_VERSION         = 0x70, // module fw version.
+    MD_SND_CMD_INVALID_DATA               = 0x00, // unused
+};
+
+enum {
+    MD_REV_CMD_RAW                  = 0xAF,
+    MD_REV_CMD_RAW_OUT              = 0x60,
+    MD_REV_CMD_INDICATOR            = 0x5A,
+    MD_REV_CMD_DEVCTRL              = 0x5B,
+    MD_REV_CMD_DEVCTRL_BAT_LOW      = 0x21, // unused
+    MD_REV_CMD_DEVCTRL_BAT_PWROFF   = 0x22, // unused
+    MD_REV_CMD_DEVCTRL_BAT_NORMAL   = 0x23, // unused
+    MD_REV_CMD_DEVCTRL_PAIRING      = 0x31,
+    MD_REV_CMD_DEVCTRL_CONNECTED    = 0x32,
+    MD_REV_CMD_DEVCTRL_DISCONNECTED = 0x33,
+    MD_REV_CMD_DEVCTRL_DONE         = 0x34, // reserved
+    MD_REV_CMD_DEVCTRL_RECONNECT    = 0x35, // reserved
+    MD_REV_CMD_DEVCTRL_REJECT       = 0x36,
+    MD_REV_CMD_DEVCTRL_UNPAIRED     = 0x37, // reserved
+    MD_REV_CMD_DEVCTRL_MD_WAKEUP    = 0x42, // unused
+    MD_REV_CMD_DEVCTRL_CLS_UART     = 0x43, // unused
+    MD_REV_CMD_BATVOL               = 0x5C,
+    MD_REV_CMD_MD_FW_VERSION        = 0x5D,
+    MD_REV_CMD_HOST_STATE           = 0x60,
+    MD_REV_CMD_HOST_STATE_SUSPEND   = 0x00,
+    MD_REV_CMD_HOST_STATE_RESUME    = 0x01,
+};
+
+enum {
+    BURST                           = 0xB2,
+    CONTINUE                        = 0xB3,
+    STOP                            = 0xB4,
+};
+
+void md_init(void);
+void md_main_task(void);
+void md_send_kb(uint8_t *data);
+void md_send_nkro(uint8_t *data);
+void md_send_consumer(uint8_t *data);
+void md_send_system(uint8_t *data);
+void md_send_fn(uint8_t *data);
+void md_send_mouse(uint8_t *data);
+void md_send_devctrl(uint8_t cmd);
+void md_send_manufacturer(char *str, uint8_t len);
+void md_send_product(char *str, uint8_t len);
+void md_send_vpid(uint16_t vid, uint16_t pid);
+void md_send_raw(uint8_t *data, uint8_t length);
+void md_send_pkt(uint8_t *data, uint32_t len);
+bool md_receive_process_user(uint8_t *pdata, uint8_t len);
+void md_devs_change(uint8_t devs, bool reset);
+bool md_inquire_bat(void);
+uint8_t md_get_version(void);
+uint8_t *md_getp_state(void);
+uint8_t *md_getp_bat(void);
+uint8_t *md_getp_indicator(void);
+void md_rf_send_carrier(uint8_t channel, uint8_t tx_power, uint8_t phy);
+void md_rf_send_stop(void);
+void md_send_devctrl_bat(uint8_t cmd);

--- a/keyboards/epomaker/split70/linker/wireless/rgb_matrix_blink.c
+++ b/keyboards/epomaker/split70/linker/wireless/rgb_matrix_blink.c
@@ -1,0 +1,174 @@
+// Copyright 2024 JoyLee (@itarze)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include <stddef.h>
+#include "rgb_matrix.h"
+#include "rgb_matrix_blink.h"
+#include "timer.h"
+
+#define NUM_BLINK_RGBS (sizeof(blink_rgbs) / sizeof(blink_rgbs[0]))
+
+// /* Example */
+// blink_rgb_t blink_rgbs[RGB_MATRIX_BLINK_COUNT] = {
+//     {.index = 1, .interval = 250, .times = 5, .color = {.r = 0xFF, .g = 0xFF, .b = 0xFF}, .blink_cb = NULL},
+//     {.index = 0xFF, .interval = 250, .times = 5, .color = {.r = 0xFF, .g = 0x00, .b = 0x00}, .blink_cb = NULL},
+// };
+
+bool rgb_matrix_blink_set(uint8_t index) {
+
+    for (uint8_t i = 0; i < NUM_BLINK_RGBS; i++) {
+        if (blink_rgbs[i].index == index) {
+            if (blink_rgbs[i].times < 1) {
+                return false;
+            }
+            blink_rgbs[i].remain_time = blink_rgbs[i].interval * blink_rgbs[i].times * 2 + 1;
+            if (blink_rgbs[i].times == 0xFF) {
+                blink_rgbs[i].remain_time = blink_rgbs[i].interval + 1;
+            }
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool rgb_matrix_blink_set_color(uint8_t index, uint8_t r, uint8_t g, uint8_t b) {
+
+    for (uint8_t i = 0; i < NUM_BLINK_RGBS; i++) {
+        if (blink_rgbs[i].index == index) {
+            blink_rgbs[i].color.r = r;
+            blink_rgbs[i].color.g = g;
+            blink_rgbs[i].color.b = b;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool rgb_matrix_blink_set_cb(uint8_t index, void *blink_cb) {
+
+    for (uint8_t i = 0; i < NUM_BLINK_RGBS; i++) {
+        if (blink_rgbs[i].index == index) {
+            blink_rgbs[i].blink_cb = blink_cb;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool rgb_matrix_blink_set_interval(uint8_t index, uint32_t interval) {
+
+    for (uint8_t i = 0; i < NUM_BLINK_RGBS; i++) {
+        if (blink_rgbs[i].index == index) {
+            blink_rgbs[i].interval = interval;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool rgb_matrix_blink_set_times(uint8_t index, uint32_t times) {
+
+    for (uint8_t i = 0; i < NUM_BLINK_RGBS; i++) {
+        if (blink_rgbs[i].index == index) {
+            blink_rgbs[i].times = times;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool rgb_matrix_blink_set_remain_time(uint8_t index, uint32_t time) {
+
+    for (uint8_t i = 0; i < NUM_BLINK_RGBS; i++) {
+        if (blink_rgbs[i].index == index) {
+            blink_rgbs[i].remain_time = time;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool rgb_matrix_blink_set_interval_times(uint8_t index, uint32_t interval, uint32_t times) {
+
+    for (uint8_t i = 0; i < NUM_BLINK_RGBS; i++) {
+        if (blink_rgbs[i].index == index) {
+            blink_rgbs[i].interval = interval;
+            blink_rgbs[i].times    = times;
+            blink_rgbs[i].time     = 0x00;
+            blink_rgbs[i].flip     = false;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+__attribute__((weak)) bool rgb_matrix_blink_user(blink_rgb_t *blink_rgb) {
+    return true;
+}
+
+bool rgb_matrix_blink_task(uint8_t led_min, uint8_t led_max) {
+
+    for (uint8_t rgb_index = 0; rgb_index < NUM_BLINK_RGBS; rgb_index++) {
+        if (blink_rgbs[rgb_index].remain_time != 0) {
+            if ((blink_rgbs[rgb_index].time == 0) || (timer_elapsed32(blink_rgbs[rgb_index].time) >= blink_rgbs[rgb_index].interval)) {
+                blink_rgbs[rgb_index].flip = !blink_rgbs[rgb_index].flip;
+                blink_rgbs[rgb_index].time = timer_read32();
+
+                if (blink_rgbs[rgb_index].remain_time >= blink_rgbs[rgb_index].interval) {
+                    blink_rgbs[rgb_index].remain_time -= blink_rgbs[rgb_index].interval;
+                } else {
+                    blink_rgbs[rgb_index].remain_time = 0;
+                    blink_rgbs[rgb_index].flip        = false;
+                    blink_rgbs[rgb_index].time        = 0;
+                }
+            }
+
+            if (blink_rgbs[rgb_index].remain_time == 0) {
+                if (blink_rgbs[rgb_index].blink_cb != NULL) {
+                    blink_rgbs[rgb_index].blink_cb(blink_rgbs[rgb_index].index);
+                }
+                if (blink_rgbs[rgb_index].index == 0xFF) {
+                    rgb_matrix_set_color_all(0x00, 0x00, 0x00);
+                } else if (blink_rgbs[rgb_index].index < RGB_MATRIX_LED_COUNT) {
+                    rgb_matrix_set_color(blink_rgbs[rgb_index].index, 0x00, 0x00, 0x00);
+                }
+                continue;
+            }
+
+            if (rgb_matrix_blink_user(&blink_rgbs[rgb_index]) != true) {
+                continue;
+            }
+
+            if (blink_rgbs[rgb_index].flip) {
+                if (blink_rgbs[rgb_index].index == 0xFF) {
+                    rgb_matrix_set_color_all(blink_rgbs[rgb_index].color.r,
+                                             blink_rgbs[rgb_index].color.g,
+                                             blink_rgbs[rgb_index].color.b);
+                } else if (blink_rgbs[rgb_index].index < RGB_MATRIX_LED_COUNT) {
+                    rgb_matrix_set_color(blink_rgbs[rgb_index].index,
+                                         blink_rgbs[rgb_index].color.r,
+                                         blink_rgbs[rgb_index].color.g,
+                                         blink_rgbs[rgb_index].color.b);
+                }
+            } else {
+                if (blink_rgbs[rgb_index].index == 0xFF) {
+                    rgb_matrix_set_color_all(0x00, 0x00, 0x00);
+                } else if (blink_rgbs[rgb_index].index < RGB_MATRIX_LED_COUNT) {
+                    rgb_matrix_set_color(blink_rgbs[rgb_index].index, 0x00, 0x00, 0x00);
+                }
+            }
+        } else {
+            blink_rgbs[rgb_index].flip = false;
+            blink_rgbs[rgb_index].time = 0;
+        }
+    }
+
+    return true;
+}

--- a/keyboards/epomaker/split70/linker/wireless/rgb_matrix_blink.h
+++ b/keyboards/epomaker/split70/linker/wireless/rgb_matrix_blink.h
@@ -1,0 +1,31 @@
+// Copyright 2024 JoyLee (@itarze)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+typedef struct {
+    uint32_t interval;
+    uint32_t remain_time;
+    uint32_t times;
+    uint32_t time;
+    uint8_t index;
+    uint8_t flip;
+    void (*blink_cb)(uint8_t);
+    RGB color;
+} blink_rgb_t;
+
+#ifndef RGB_MATRIX_BLINK_COUNT
+#    define RGB_MATRIX_BLINK_COUNT 0
+#endif
+
+extern blink_rgb_t blink_rgbs[RGB_MATRIX_BLINK_COUNT];
+
+bool rgb_matrix_blink_set(uint8_t index);
+bool rgb_matrix_blink_set_color(uint8_t index, uint8_t r, uint8_t g, uint8_t b);
+bool rgb_matrix_blink_set_cb(uint8_t index, void *blink_cb);
+bool rgb_matrix_blink_set_interval(uint8_t index, uint32_t interval);
+bool rgb_matrix_blink_set_times(uint8_t index, uint32_t times);
+bool rgb_matrix_blink_set_remain_time(uint8_t index, uint32_t time);
+bool rgb_matrix_blink_set_interval_times(uint8_t index, uint32_t interval, uint32_t times);
+bool rgb_matrix_blink_task(uint8_t led_min, uint8_t led_max);
+bool rgb_matrix_blink_user(blink_rgb_t *blink_rgb);

--- a/keyboards/epomaker/split70/linker/wireless/smsg.c
+++ b/keyboards/epomaker/split70/linker/wireless/smsg.c
@@ -1,0 +1,122 @@
+// Copyright 2024 Su (@isuua)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "smsg.h"
+#include <string.h>
+
+#ifndef SMSG_NUM
+#    define SMSG_NUM 40
+#endif
+
+#ifndef SMSG_PAYLOAD_LEN
+#    define SMSG_PAYLOAD_LEN 50
+#endif
+
+#define SMSG_BUF_SIZE (SMSG_NUM * SMSG_PAYLOAD_LEN)
+#define END_PTR ((smsg_ptr_t *)&smsg_instance.ptr[SMSG_NUM - 1])
+#define FREE_SPACE ((uint32_t)(&smsg_buffer[SMSG_BUF_SIZE - 1] - smsg_instance.buffer))
+
+typedef struct {
+    uint8_t *head;
+    uint8_t *tail;
+} smsg_ptr_t;
+
+typedef struct {
+    smsg_states_t state;
+    smsg_ptr_t *ptr;
+    smsg_ptr_t *in_ptr;
+    smsg_ptr_t *out_ptr;
+    uint8_t *buffer;
+} smsg_t;
+
+static smsg_ptr_t smsg_ptr[SMSG_NUM];
+static uint8_t smsg_buffer[SMSG_BUF_SIZE];
+static smsg_t smsg_instance;
+
+void smsg_init(void) {
+
+    smsg_instance.buffer    = smsg_buffer;
+    smsg_instance.ptr       = smsg_ptr;
+    smsg_instance.ptr->head = smsg_instance.buffer;
+    smsg_instance.ptr->tail = smsg_instance.buffer;
+    smsg_instance.in_ptr    = smsg_instance.ptr;
+    smsg_instance.out_ptr   = smsg_instance.ptr;
+    smsg_instance.state     = smsg_state_free;
+}
+
+bool smsg_push(uint8_t *buf, uint32_t size) {
+
+    if (smsg_instance.in_ptr == END_PTR) {
+        if (smsg_instance.ptr == smsg_instance.out_ptr) {
+            return false;
+        }
+    } else {
+        if ((smsg_instance.in_ptr + 1) == smsg_instance.out_ptr) {
+            return false;
+        }
+    }
+
+    if (FREE_SPACE < SMSG_PAYLOAD_LEN) {
+        smsg_instance.buffer = smsg_buffer;
+    }
+
+    if (size > SMSG_PAYLOAD_LEN) {
+        return false;
+    }
+
+    memcpy(smsg_instance.buffer, buf, size);
+    smsg_instance.in_ptr->head = smsg_instance.buffer;
+    smsg_instance.buffer += size;
+    smsg_instance.in_ptr->tail = smsg_instance.buffer;
+    if (smsg_instance.in_ptr == END_PTR) {
+        smsg_instance.in_ptr = smsg_instance.ptr;
+    } else {
+        smsg_instance.in_ptr++;
+    }
+
+    return true;
+}
+
+uint32_t smsg_peek(uint8_t *buf) {
+
+    if (smsg_instance.out_ptr != smsg_instance.in_ptr) {
+        uint32_t size;
+
+        size = smsg_instance.out_ptr->tail - smsg_instance.out_ptr->head;
+        memcpy(buf, smsg_instance.out_ptr->head, size);
+
+        return size;
+    }
+
+    return 0;
+}
+
+void smsg_pop(void) {
+
+    if (smsg_instance.out_ptr != smsg_instance.in_ptr) {
+        if (smsg_instance.out_ptr == END_PTR) {
+            smsg_instance.out_ptr = smsg_instance.ptr;
+        } else {
+            smsg_instance.out_ptr++;
+        }
+    }
+}
+
+smsg_states_t smsg_get_state(void) {
+
+    return smsg_instance.state;
+}
+
+void smsg_set_state(smsg_states_t state) {
+
+    smsg_instance.state = state;
+}
+
+bool smsg_is_busy(void) {
+
+    if (smsg_instance.out_ptr != smsg_instance.in_ptr) {
+        return true;
+    }
+
+    return false;
+}

--- a/keyboards/epomaker/split70/linker/wireless/smsg.h
+++ b/keyboards/epomaker/split70/linker/wireless/smsg.h
@@ -1,0 +1,22 @@
+// Copyright 2024 Su (@isuua)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef enum {
+    smsg_state_free = 0,
+    smsg_state_busy,
+    smsg_state_retry,
+    smsg_state_replied
+} smsg_states_t;
+
+void smsg_init(void);
+bool smsg_push(uint8_t *buf, uint32_t size);
+uint32_t smsg_peek(uint8_t *buf);
+void smsg_pop(void);
+smsg_states_t smsg_get_state(void);
+void smsg_set_state(smsg_states_t state);
+bool smsg_is_busy(void);

--- a/keyboards/epomaker/split70/linker/wireless/transport.c
+++ b/keyboards/epomaker/split70/linker/wireless/transport.c
@@ -1,0 +1,172 @@
+// Copyright 2024 Su (@isuua)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "quantum.h"
+#include "module.h"
+#include "usb_main.h"
+#include "transport.h"
+#include "wireless.h"
+
+#ifndef USB_POWER_DOWN_DELAY
+#    define USB_POWER_DOWN_DELAY 7000
+#endif
+
+extern host_driver_t chibios_driver;
+extern host_driver_t wireless_driver;
+
+static transport_t transport = TRANSPORT_USB;
+
+void wls_transport_enable(bool enable) __attribute__((weak));
+void wls_transport_enable(bool enable) {
+
+    if (enable) {
+        if (host_get_driver() != &wireless_driver) {
+            host_set_driver(&wireless_driver);
+            usb_device_state_set_protocol(USB_PROTOCOL_REPORT);  // default with true
+        }
+    } else {
+        if (*md_getp_state() == MD_STATE_CONNECTED) {
+            wireless_driver.send_keyboard(NULL);
+            wireless_driver.send_nkro(NULL);
+        }
+    }
+}
+
+/* Control USB device connection and disconnection by
+ * controlling the power supply of the USB DP pull-up resistor.
+ * Overwrite these two functions. */
+void usb_power_connect(void) __attribute__((weak));
+void usb_power_connect(void) {}
+
+void usb_power_disconnect(void) __attribute__((weak));
+void usb_power_disconnect(void) {}
+
+void usb_transport_enable(bool enable) __attribute__((weak));
+void usb_transport_enable(bool enable) {
+
+    if (enable) {
+        if (host_get_driver() != &chibios_driver) {
+            extern bool last_suspend_state;
+
+            /* This flag is not set to 1 with probability after usb restart */
+            last_suspend_state = true;
+#if !defined(KEEP_USB_CONNECTION_IN_WIRELESS_MODE)
+            usb_power_connect();
+            restart_usb_driver(&USBD1);
+#endif
+            host_set_driver(&chibios_driver);
+        }
+    } else {
+        if (USB_DRIVER.state == USB_ACTIVE) {
+            chibios_driver.send_keyboard(NULL);
+            chibios_driver.send_nkro(NULL);
+        }
+
+#if !defined(KEEP_USB_CONNECTION_IN_WIRELESS_MODE)
+        usbStop(&USBD1);
+        usbDisconnectBus(&USBD1);
+        usb_power_disconnect();
+#endif
+    }
+}
+
+void set_transport(transport_t new_transport) {
+
+    if (transport != new_transport) {
+        transport = new_transport;
+
+        switch (transport) {
+            case TRANSPORT_USB: {
+                wls_transport_enable(false);
+                usb_transport_enable(true);
+            } break;
+            case TRANSPORT_WLS: {
+                usb_transport_enable(false);
+                wls_transport_enable(true);
+            } break;
+            default:
+                break;
+        }
+    }
+}
+
+transport_t get_transport(void) {
+
+    return transport;
+}
+uint32_t suspend_timer = 0x00;
+void usb_remote_wakeup(void) {
+    if (wireless_get_current_devs() == DEVS_USB){
+#ifdef USB_REMOTE_USE_QMK
+    if (USB_DRIVER.state == USB_SUSPENDED) {
+        dprintln("suspending keyboard");
+        while (USB_DRIVER.state == USB_SUSPENDED) {
+            /* Do this in the suspended state */
+            suspend_power_down(); // on AVR this deep sleeps for 15ms
+            /* Remote wakeup */
+            if ((USB_DRIVER.status & 2U) && suspend_wakeup_condition()) {
+                usbWakeupHost(&USB_DRIVER);
+#    if USB_SUSPEND_WAKEUP_DELAY > 0
+                // Some hubs, kvm switches, and monitors do
+                // weird things, with USB device state bouncing
+                // around wildly on wakeup, yielding race
+                // conditions that can corrupt the keyboard state.
+                //
+                // Pause for a while to let things settle...
+                wait_ms(USB_SUSPEND_WAKEUP_DELAY);
+#    endif
+            }
+        }
+        /* Woken up */
+    }
+#else
+
+    if ((USB_DRIVER.state == USB_SUSPENDED)) {
+        if (!suspend_timer) suspend_timer = sync_timer_read32();
+        if (sync_timer_elapsed32(suspend_timer) >= USB_POWER_DOWN_DELAY) {
+            suspend_timer = 0x00;
+            extern void lpwr_set_timeout_manual(bool enable);
+            // suspend_power_down();
+            lpwr_set_timeout_manual(true);
+        }
+    } else {
+        suspend_timer = 0x00;
+    }
+#endif
+    } else {
+        suspend_timer = 0x00;
+    }
+}
+
+#ifndef USB_REMOTE_USE_QMK
+void usb_remote_host(void) {
+
+    if (USB_DRIVER.state == USB_SUSPENDED) {
+        if ((USB_DRIVER.status & 2U) && suspend_wakeup_condition()) {
+            usbWakeupHost(&USB_DRIVER);
+#    if USB_SUSPEND_WAKEUP_DELAY > 0
+            // Some hubs, kvm switches, and monitors do
+            // weird things, with USB device state bouncing
+            // around wildly on wakeup, yielding race
+            // conditions that can corrupt the keyboard state.
+            //
+            // Pause for a while to let things settle...
+            wait_ms(USB_SUSPEND_WAKEUP_DELAY);
+#    endif
+        }
+#    if !defined(USB_REMOTE_USE_QMK) && USB_POWER_DOWN_DELAY
+        suspend_wakeup_init();
+#    endif
+    }
+}
+
+bool process_action_kb(keyrecord_t *record) {
+
+    (void)record;
+    if (get_transport() == TRANSPORT_USB){
+        usb_remote_host();
+    }
+
+    return true;
+}
+#endif

--- a/keyboards/epomaker/split70/linker/wireless/transport.h
+++ b/keyboards/epomaker/split70/linker/wireless/transport.h
@@ -1,0 +1,18 @@
+// Copyright 2024 Su (@isuua)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+typedef enum {
+    TRANSPORT_NONE,
+    TRANSPORT_USB,
+    TRANSPORT_WLS,
+} transport_t;
+
+void wls_transport_enable(bool enable);
+void usb_transport_enable(bool enable);
+void set_transport(transport_t new_transport);
+transport_t get_transport(void);
+void usb_power_connect(void);
+void usb_power_disconnect(void);
+void usb_remote_wakeup(void);

--- a/keyboards/epomaker/split70/linker/wireless/wireless.c
+++ b/keyboards/epomaker/split70/linker/wireless/wireless.c
@@ -1,0 +1,305 @@
+// Copyright 2024 Su (@isuua)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "quantum.h"
+#include "wireless.h"
+
+#ifndef WLS_INQUIRY_BAT_TIME
+#    define WLS_INQUIRY_BAT_TIME 3000
+#endif
+
+static uint8_t wls_devs = DEVS_USB;
+bool im_test_rate_flag;
+
+void last_matrix_activity_trigger(void);
+
+uint8_t wireless_keyboard_leds(void);
+void wireless_send_keyboard(report_keyboard_t *report);
+void wireless_send_nkro(report_nkro_t *report);
+void wireless_send_mouse(report_mouse_t *report);
+void wireless_send_extra(report_extra_t *report);
+
+host_driver_t wireless_driver = {
+    .keyboard_leds = wireless_keyboard_leds,
+    .send_keyboard = wireless_send_keyboard,
+    .send_nkro     = wireless_send_nkro,
+    .send_mouse    = wireless_send_mouse,
+    .send_extra    = wireless_send_extra,
+};
+
+void wireless_init(void) {
+
+    md_init();
+}
+
+uint8_t wireless_keyboard_leds(void) {
+
+    if (*md_getp_state() == MD_STATE_CONNECTED) {
+        return *md_getp_indicator();
+    }
+
+    return 0;
+}
+
+void wireless_send_keyboard(report_keyboard_t *report) {
+    if(MD_STATE_PAIRING == *md_getp_state()){
+        return;
+    }
+    uint8_t wls_report_kb[MD_SND_CMD_KB_LEN] = {0};
+
+    if (*md_getp_state() != MD_STATE_CONNECTED) {
+        wireless_devs_change(wls_devs, wls_devs, false);
+        return;
+    }
+
+    if (report != NULL) {
+        memcpy(wls_report_kb, (uint8_t *)report, sizeof(wls_report_kb));
+    }
+    md_send_kb(wls_report_kb);
+}
+
+void wireless_send_nkro(report_nkro_t *report) {
+    static report_keyboard_t temp_report_keyboard = {0};
+    uint8_t wls_report_nkro[MD_SND_CMD_NKRO_LEN]  = {0};
+
+    if(MD_STATE_PAIRING == *md_getp_state()){
+        return;
+    }
+
+    if (*md_getp_state() != MD_STATE_CONNECTED) {
+        wireless_devs_change(wls_devs, wls_devs, false);
+        return;
+    }
+
+    if (report != NULL) {
+        report_nkro_t temp_report_nkro = *report;
+        uint8_t key_count              = 0;
+
+        temp_report_keyboard.mods = temp_report_nkro.mods;
+        for (uint8_t i = 0; i < NKRO_REPORT_BITS; i++) {
+            key_count += __builtin_popcount(temp_report_nkro.bits[i]);
+        }
+
+        // find key up and del it.
+        for (uint8_t i = 0; i < KEYBOARD_REPORT_KEYS && temp_report_keyboard.keys[i]; i++) {
+            uint8_t usageid = 0x00;
+            uint8_t n;
+
+            for (uint8_t c = 0; c < key_count; c++) {
+                for (n = 0; n < NKRO_REPORT_BITS && !temp_report_nkro.bits[n]; n++) {}
+                usageid = (n << 3) | biton(temp_report_nkro.bits[n]);
+#ifdef NKRO_ENABLE
+                del_key_bit(&temp_report_nkro, usageid);
+#endif
+                if (usageid == temp_report_keyboard.keys[i]) {
+                    break;
+                }
+            }
+
+            if (usageid != temp_report_keyboard.keys[i]) {
+                temp_report_keyboard.keys[i] = 0x00;
+            }
+        }
+
+        /*
+         * Use NKRO for sending when more than 6 keys are pressed
+         * to solve the issue of the lack of a protocol flag in wireless mode.
+         */
+
+        temp_report_nkro = *report;
+
+        for (uint8_t i = 0; i < key_count; i++) {
+            uint8_t usageid;
+            uint8_t idx, n = 0;
+
+            for (n = 0; n < NKRO_REPORT_BITS && !temp_report_nkro.bits[n]; n++) {}
+            usageid = (n << 3) | biton(temp_report_nkro.bits[n]);
+#ifdef NKRO_ENABLE
+            del_key_bit(&temp_report_nkro, usageid);
+#endif
+
+            for (idx = 0; idx < KEYBOARD_REPORT_KEYS; idx++) {
+                if (temp_report_keyboard.keys[idx] == usageid) {
+                    break;
+                }
+                if (temp_report_keyboard.keys[idx] == 0x00) {
+                    temp_report_keyboard.keys[idx] = usageid;
+                    break;
+                }
+            }
+
+            if (idx == KEYBOARD_REPORT_KEYS && (usageid < (MD_SND_CMD_NKRO_LEN * 8))) {
+                wls_report_nkro[usageid / 8] |= 0x01 << (usageid % 8);
+            }
+        }
+    } else {
+        memset(&temp_report_keyboard, 0, sizeof(temp_report_keyboard));
+    }
+
+    // wireless_driver.send_keyboard(&temp_report_keyboard);
+    while(smsg_is_busy()) wireless_task(); // AI said to comment this out to help with lockups
+    host_keyboard_send(&temp_report_keyboard);
+    md_send_nkro(wls_report_nkro);
+}
+
+void wireless_send_mouse(report_mouse_t *report) {
+
+    if(MD_STATE_PAIRING == *md_getp_state()){
+        return;
+    }
+
+    typedef struct {
+        uint8_t buttons;
+        int8_t x;
+        int8_t y;
+        int8_t z;
+        int8_t h;
+    } __attribute__((packed)) wls_report_mouse_t;
+
+    wls_report_mouse_t wls_report_mouse = {0};
+
+    if (*md_getp_state() != MD_STATE_CONNECTED) {
+        wireless_devs_change(wls_devs, wls_devs, false);
+        return;
+    }
+
+    if (report != NULL) {
+        wls_report_mouse.buttons = report->buttons;
+        wls_report_mouse.x       = report->x;
+        wls_report_mouse.y       = report->y;
+        wls_report_mouse.z       = report->h;
+        wls_report_mouse.h       = report->v;
+    }
+
+    md_send_mouse((uint8_t *)&wls_report_mouse);
+}
+
+void wireless_send_extra(report_extra_t *report) {
+    if(MD_STATE_PAIRING == *md_getp_state()){
+        return;
+    }
+
+    uint16_t usage = 0;
+
+    if (*md_getp_state() != MD_STATE_CONNECTED) {
+        wireless_devs_change(wls_devs, wls_devs, false);
+        return;
+    }
+
+    if (report != NULL) {
+        usage = report->usage;
+
+        switch (usage) {
+            case 0x81:
+            case 0x82:
+            case 0x83: { // system usage
+                usage = 0x01 << (usage - 0x81);
+                md_send_system((uint8_t *)&usage);
+            } break;
+            default: {
+                md_send_consumer((uint8_t *)&usage);
+            } break;
+        }
+    }
+}
+
+void wireless_devs_change_user(uint8_t old_devs, uint8_t new_devs, bool reset) __attribute__((weak));
+void wireless_devs_change_user(uint8_t old_devs, uint8_t new_devs, bool reset) {}
+
+void wireless_devs_change_kb(uint8_t old_devs, uint8_t new_devs, bool reset) __attribute__((weak));
+void wireless_devs_change_kb(uint8_t old_devs, uint8_t new_devs, bool reset) {}
+
+void wireless_devs_change(uint8_t old_devs, uint8_t new_devs, bool reset) {
+    bool changed = (old_devs == DEVS_USB) ? (new_devs != DEVS_USB) : (new_devs == DEVS_USB);
+
+    if (changed) {
+        set_transport((new_devs != DEVS_USB) ? TRANSPORT_WLS : TRANSPORT_USB);
+    }
+
+    if ((wls_devs != new_devs) || reset) {
+        *md_getp_state()     = MD_STATE_DISCONNECTED;
+        *md_getp_indicator() = 0;
+    }
+
+    wls_devs = new_devs;
+    last_matrix_activity_trigger();
+
+    md_devs_change(new_devs, reset);
+    wireless_devs_change_kb(old_devs, new_devs, reset);
+    wireless_devs_change_user(old_devs, new_devs, reset);
+}
+
+uint8_t wireless_get_current_devs(void) {
+    return wls_devs;
+}
+
+void usb_mode_test_report_task(void) {
+    extern void host_mouse_send(report_mouse_t * report);
+
+    static uint8_t flip                = 0;
+    static report_mouse_t mouse_format = {0};
+
+    switch (flip) {
+        case 0: {
+            mouse_format.x = 10;
+            mouse_format.y = 0;
+            host_mouse_send(&mouse_format);
+            flip = 1;
+        } break;
+        case 1: {
+            mouse_format.x = 0;
+            mouse_format.y = -10;
+            host_mouse_send(&mouse_format);
+            flip = 2;
+        } break;
+        case 2: {
+            mouse_format.x = -10;
+            mouse_format.y = 0;
+            host_mouse_send(&mouse_format);
+            flip = 3;
+        } break;
+        case 3: {
+            mouse_format.x = 0;
+            mouse_format.y = 10;
+            host_mouse_send(&mouse_format);
+            flip = 0;
+        } break;
+        default: {
+            flip = 0;
+        } break;
+    }
+}
+
+void wireless_pre_task(void) __attribute__((weak));
+void wireless_pre_task(void) {}
+
+void wireless_post_task(void) __attribute__((weak));
+void wireless_post_task(void) {}
+
+void wireless_task(void) {
+
+    wireless_pre_task();
+    lpwr_task();
+    md_main_task();
+    wireless_post_task();
+
+    /* usb_remote_wakeup() should be invoked last so that we have chance
+     * to switch to wireless after start-up when usb is not connected
+     */
+    if (get_transport() == TRANSPORT_USB) {
+        usb_remote_wakeup();
+    } else if (lpwr_get_state() == LPWR_NORMAL) {
+        static uint32_t inqtimer = 0x00;
+
+        if (sync_timer_elapsed32(inqtimer) >= (WLS_INQUIRY_BAT_TIME)) {
+            if (md_inquire_bat()) {
+                inqtimer = sync_timer_read32();
+            }
+        }
+    }
+}
+
+// void housekeeping_task_kb(void) {
+//     if (wireless_get_current_devs() == DEVS_USB && im_test_rate_flag) usb_mode_test_report_task();
+//     wireless_task();
+// }

--- a/keyboards/epomaker/split70/linker/wireless/wireless.h
+++ b/keyboards/epomaker/split70/linker/wireless/wireless.h
@@ -1,0 +1,16 @@
+// Copyright 2024 Su (@isuua)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include "transport.h"
+#include "lowpower.h"
+#include "module.h"
+#include "smsg.h"
+
+void wireless_init(void);
+void wireless_devs_change(uint8_t old_devs, uint8_t new_devs, bool reset);
+uint8_t wireless_get_current_devs(void);
+void wireless_pre_task(void);
+void wireless_post_task(void);
+void wireless_task(void);

--- a/keyboards/epomaker/split70/linker/wireless/wireless.mk
+++ b/keyboards/epomaker/split70/linker/wireless/wireless.mk
@@ -1,0 +1,31 @@
+WIRELESS_ENABLE ?= yes
+WIRELESS_DIR = $(TOP_DIR)/keyboards/$(KEYBOARD)/linker/wireless
+
+ifeq ($(strip $(WIRELESS_ENABLE)), yes)
+    OPT_DEFS += -DWIRELESS_ENABLE -DNO_USB_STARTUP_CHECK
+
+    # quantum/via.c calls raw_hid_send() directly to forward HID reports.
+    # Redirect just that one translation unit to our wireless-aware
+    # replaced_hid_send() so quantum/raw_hid.c's USB-only implementation is
+    # left untouched (no core files modified, no symbol clash).
+    $(INTERMEDIATE_OUTPUT)/quantum/via.o: FILE_SPECIFIC_CFLAGS += -Draw_hid_send=replaced_hid_send
+
+    UART_DRIVER_REQUIRED ?= yes
+    WIRELESS_LPWR_STOP_ENABLE ?= yes
+
+    VPATH += $(WIRELESS_DIR)
+
+    SRC += \
+        $(WIRELESS_DIR)/wireless.c \
+        $(WIRELESS_DIR)/transport.c \
+        $(WIRELESS_DIR)/lowpower.c \
+        $(WIRELESS_DIR)/md_raw.c \
+        $(WIRELESS_DIR)/smsg.c \
+        $(WIRELESS_DIR)/rgb_matrix_blink.c \
+        $(WIRELESS_DIR)/module.c
+
+    ifeq ($(strip $(WIRELESS_LPWR_STOP_ENABLE)), yes)
+        OPT_DEFS += -DWIRELESS_LPWR_STOP_ENABLE
+        SRC += $(WIRELESS_DIR)/lpwr_wb32.c
+    endif
+endif

--- a/keyboards/epomaker/split70/mcuconf.h
+++ b/keyboards/epomaker/split70/mcuconf.h
@@ -1,0 +1,44 @@
+// Copyright 2024 Epomaker (@Epomaker)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#pragma once
+
+#include_next <mcuconf.h>
+
+#undef WB32_USB_HOST_WAKEUP_DURATION
+#define WB32_USB_HOST_WAKEUP_DURATION 2
+
+#undef WB32_SERIAL_USE_UART1
+#define WB32_SERIAL_USE_UART1 TRUE
+
+#undef WB32_SERIAL_USE_UART3
+#define WB32_SERIAL_USE_UART3 TRUE
+
+#undef WB32_SPI_USE_SPIM2
+#define WB32_SPI_USE_SPIM2 TRUE
+
+#undef WB32_SPI_USE_QSPI
+#define WB32_SPI_USE_QSPI TRUE
+
+// The interrupt priority of the WS2812 driver must be higher than that of other SPI devices.
+#undef WB32_SPI_SPIM2_IRQ_PRIORITY
+#define WB32_SPI_SPIM2_IRQ_PRIORITY 9
+
+#undef WB32_SERIAL_UART1_PRIORITY
+#define WB32_SERIAL_UART1_PRIORITY 10
+
+#undef WB32_SPI_QSPI_IRQ_PRIORITY
+#define WB32_SPI_QSPI_IRQ_PRIORITY 10
+
+#undef WB32_SERIAL_UART3_PRIORITY
+#define WB32_SERIAL_UART3_PRIORITY 8
+
+/* system clock set to 96Mhz */
+#undef WB32_PLLDIV_VALUE
+#define WB32_PLLDIV_VALUE 2
+
+#undef WB32_PLLMUL_VALUE
+#define WB32_PLLMUL_VALUE 16
+
+#undef WB32_USBPRE
+#define WB32_USBPRE WB32_USBPRE_DIV2

--- a/keyboards/epomaker/split70/post_rules.mk
+++ b/keyboards/epomaker/split70/post_rules.mk
@@ -1,0 +1,6 @@
+RGB_MATRIX_CUSTOM_USER = yes
+include keyboards/epomaker/split70/rgb_record/rgb_record.mk
+include keyboards/epomaker/split70/wls/wls.mk
+include keyboards/epomaker/split70/linker/wireless/wireless.mk
+
+# include keyboards/linker/wireless/wireless.mk

--- a/keyboards/epomaker/split70/readme.md
+++ b/keyboards/epomaker/split70/readme.md
@@ -1,0 +1,29 @@
+# Epomaker Split70
+
+- Keyboard Maintainer: [Epomaker](https://github.com/Epomaker)
+- Hardware Supported: Epomaker Split70
+- Hardware Availability: Epomaker Split70
+
+Make example for this keyboard (after setting up your build environment):
+
+    make epomaker/split70:default
+
+Flashing example for this keyboard:
+
+    make leo/epomaker_split70:default
+
+To reset the board into bootloader mode, do one of the following:
+
+- Hold the Reset switch mounted on the bottom side of the PCB while connecting the USB cable
+- Hold the Escape key while connecting the USB cable (also erases persistent settings)
+- Fn+R_Shift+Esc will reset the board to bootloader mode if you have flashed the default QMK keymap
+
+See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
+
+## Bootloader
+
+Enter the bootloader in 3 ways:
+
+- **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
+- **Physical reset button**: Briefly press the button on the back of the PCB - some may have pads you must short instead
+- **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available

--- a/keyboards/epomaker/split70/readme.md
+++ b/keyboards/epomaker/split70/readme.md
@@ -10,20 +10,38 @@ Make example for this keyboard (after setting up your build environment):
 
 Flashing example for this keyboard:
 
-    make leo/epomaker_split70:default
+    make epomaker/split70:default
 
-To reset the board into bootloader mode, do one of the following:
+## Flashing the Firmware
 
-- Hold the Reset switch mounted on the bottom side of the PCB while connecting the USB cable
-- Hold the Escape key while connecting the USB cable (also erases persistent settings)
-- Fn+R_Shift+Esc will reset the board to bootloader mode if you have flashed the default QMK keymap
+**HOW TO ENTER DFU(FIRMWARE UPDATE)MODE**
+A：The Split70 is a split keyboard with two halves — the left half (with the knob) and the right half (with arrow keys).
+
+**Each half must be entered into DFU mode separately.**
+
+● **Left Half (with knob):**
+
+1. Disconnect all cables from the keyboard.
+2. Hold ESC and plug in USB-C.
+3. "Device Connected" shows on the QMK Toolbox
+
+● **Right Half(with arrow keys):**
+
+1. Disconnect all cables from the keyboard.
+2. Remove ALT and FN Keycaps and Flip the toggle switch between them down.
+   ![Remove Keys](keys.png)
+3. Remove Right Spacebar keycap and switch,short-circuit PCB holes with tweezers,then plug in USB-C.
+   ![Short Circuit PCB Holes](short_pins.png)
+4. "Device Connected"shows on the QMK Toolbox
+5. After flashing,flip ALT/FN toggle back up.
+
+**After flashing this firmware, you can do this by holding the "7" key while plugging the USB cable instead of shorting the holes. Flipping the switch to the down position is still required to flash and return to up position after flashing.
+**
+
+● Please reset the keyboard after flashing is completed.
+
+‼️ Notes:
+When updating or flashing the keyboard, MAKE SURE ONLY ONE KEYBOARDIS CONNECTED TO THE DEVICE!
+When updating or flashing the keyboard, DON'T MOVE THE KEYBOARD or PRESS ANY KEYS!
 
 See the [build environment setup](https://docs.qmk.fm/#/getting_started_build_tools) and the [make instructions](https://docs.qmk.fm/#/getting_started_make_guide) for more information. Brand new to QMK? Start with our [Complete Newbs Guide](https://docs.qmk.fm/#/newbs).
-
-## Bootloader
-
-Enter the bootloader in 3 ways:
-
-- **Bootmagic reset**: Hold down the key at (0,0) in the matrix (usually the top left key or Escape) and plug in the keyboard
-- **Physical reset button**: Briefly press the button on the back of the PCB - some may have pads you must short instead
-- **Keycode in layout**: Press the key mapped to `QK_BOOT` if it is available

--- a/keyboards/epomaker/split70/rgb_matrix_user.inc
+++ b/keyboards/epomaker/split70/rgb_matrix_user.inc
@@ -1,0 +1,18 @@
+// Copyright 2024 Epomaker (@Epomaker)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#ifdef ENABLE_RGB_MATRIX_RGBR_PLAY
+RGB_MATRIX_EFFECT(RGBR_PLAY)
+#    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+
+bool RGBR_PLAY(effect_params_t *params) {
+    RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+    extern void rgbrec_play(uint8_t led_min, uint8_t led_max);
+    rgbrec_play(led_min, led_max);
+
+    return rgb_matrix_check_finished_leds(led_max);
+}
+
+#    endif // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+#endif

--- a/keyboards/epomaker/split70/rgb_record/rgb_record.c
+++ b/keyboards/epomaker/split70/rgb_record/rgb_record.c
@@ -1,0 +1,334 @@
+// Copyright 2024 Epomaker (@Epomaker)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rgb_record.h"
+#include "rgb_matrix.h"
+#include "eeprom.h"
+
+#define RGBREC_STATE_ON  1
+#define RGBREC_STATE_OFF 0
+#define RGBREC_COLOR_NUM (sizeof(rgbrec_hs_lists) / sizeof(rgbrec_hs_lists[0]))
+
+typedef struct {
+    uint8_t state;
+    uint8_t channel;
+    uint16_t value;
+} rgbrec_info_t;
+
+typedef uint16_t (*rgbrec_effects_t)[MATRIX_COLS];
+
+rgbrec_effects_t p_rgbrec_effects = NULL;
+
+static uint16_t rgbrec_hs_lists[] = RGB_RECORD_HS_LISTS;
+static uint8_t rgbrec_buffer[MATRIX_ROWS * MATRIX_COLS * 2];
+
+//clang-format off
+static const uint8_t rgbmatrix_buff[]   = {13, 15, 16, 24, 25, 26, 29, 37, 33, 34, 35, 43, 2, 5, 6, 9};
+static const uint8_t sixth_gear_buff[]  = {6, 13, 15, 16, 25, 26, 34};
+static uint8_t rgb_hsvs[RGB_HSV_MAX][2] = {
+    {0,   255},
+    {64,  255},
+    {128, 255},
+    {192, 255},
+    {0,   0  },
+};
+
+//clang-format on
+static rgbrec_info_t rgbrec_info = {
+    .state   = RGBREC_STATE_OFF,
+    .channel = 0,
+    .value   = 0xFF,
+};
+
+static uint8_t rgbrec_buffer[MATRIX_ROWS * MATRIX_COLS * 2];
+extern const uint16_t PROGMEM rgbrec_default_effects[RGBREC_CHANNEL_NUM][MATRIX_ROWS][MATRIX_COLS];
+
+static bool find_matrix_row_col(uint8_t index, uint8_t *row, uint8_t *col) {
+    uint8_t i, j;
+
+    for (i = 0; i < MATRIX_ROWS; i++) {
+        for (j = 0; j < MATRIX_COLS; j++) {
+            if (g_led_config.matrix_co[i][j] != NO_LED) {
+                if (g_led_config.matrix_co[i][j] == index) {
+                    *row = i;
+                    *col = j;
+
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+static inline RGB hs_to_rgb(uint8_t h, uint8_t s) {
+
+    if ((h == 0) && (s == 0)) {
+        return hsv_to_rgb((HSV){0, 0, 0});
+    } else if ((h == 1) && (s == 1)) {
+        return hsv_to_rgb((HSV){0, 0, rgbrec_info.value});
+    } else {
+        return hsv_to_rgb((HSV){h, s, rgbrec_info.value});
+    }
+}
+
+void rgbrec_init(uint8_t channel) {
+
+    p_rgbrec_effects    = (rgbrec_effects_t)rgbrec_buffer;
+    rgbrec_info.state   = RGBREC_STATE_OFF;
+    rgbrec_info.channel = channel;
+    rgbrec_info.value   = rgb_matrix_get_val();
+
+    rgbrec_read_current_channel(rgbrec_info.channel);
+}
+
+bool rgbrec_show(uint8_t channel) {
+
+    if (channel >= RGBREC_CHANNEL_NUM) {
+        return false;
+    }
+
+    rgbrec_info.channel = channel;
+    rgbrec_read_current_channel(rgbrec_info.channel);
+
+    if (rgb_matrix_get_mode() != RGB_MATRIX_CUSTOM_RGBR_PLAY) {
+        rgb_matrix_mode(RGB_MATRIX_CUSTOM_RGBR_PLAY);
+    }
+
+    return true;
+}
+
+bool rgbrec_start(uint8_t channel) {
+
+    if (channel >= RGBREC_CHANNEL_NUM) {
+
+        return false;
+    }
+
+    if (rgbrec_info.state == RGBREC_STATE_OFF) {
+        rgbrec_info.state   = RGBREC_STATE_ON;
+        rgbrec_info.channel = channel;
+        rgbrec_read_current_channel(rgbrec_info.channel);
+        if (rgb_matrix_get_mode() != RGB_MATRIX_CUSTOM_RGBR_PLAY) {
+            rgb_matrix_mode(RGB_MATRIX_CUSTOM_RGBR_PLAY);
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+void rgbrec_update_current_channel(uint8_t channel) {
+    uint32_t offset = 0;
+
+    if (channel >= RGBREC_CHANNEL_NUM) {
+        return;
+    }
+
+    offset = (uint32_t)(RGBREC_EECONFIG_OFFSET) + (channel * sizeof(rgbrec_buffer));
+    eeconfig_update_user_datablock(rgbrec_buffer, offset, sizeof(rgbrec_buffer));
+}
+
+bool rgbrec_end(uint8_t channel) {
+
+    if (channel >= RGBREC_CHANNEL_NUM) {
+
+        return false;
+    }
+
+    if ((rgbrec_info.state == RGBREC_STATE_ON) && (channel == rgbrec_info.channel)) {
+        rgbrec_info.state = RGBREC_STATE_OFF;
+        rgbrec_update_current_channel(rgbrec_info.channel);
+
+        return true;
+    }
+
+    return false;
+}
+
+static inline void rgb_matrix_set_hs(int index, uint16_t hs) {
+
+    RGB rgb = hs_to_rgb(HS_GET_H(hs), HS_GET_S(hs));
+    rgb_matrix_set_color(index, rgb.r, rgb.g, rgb.b);
+}
+
+void rgbrec_play(uint8_t led_min, uint8_t led_max) {
+    uint8_t row = 0xFF, col = 0xFF;
+    uint16_t hs_color;
+
+    rgbrec_info.value = rgb_matrix_get_val();
+
+    for (uint8_t i = led_min; i < led_max; i++) {
+        if (find_matrix_row_col(i, &row, &col)) {
+            if (p_rgbrec_effects != NULL) {
+                hs_color = p_rgbrec_effects[row][col];
+                rgb_matrix_set_hs(i, hs_color);
+            }
+        }
+    }
+}
+
+void rgbrec_set_close_all(uint8_t h, uint8_t s, uint8_t v) {
+
+    if (!h && !s && !v) {
+        memset(rgbrec_buffer, 0, sizeof(rgbrec_buffer));
+    } else {
+        for (uint8_t row = 0; row < MATRIX_ROWS; row++) {
+            for (uint8_t col = 0; col < MATRIX_COLS; col++) {
+                rgbrec_buffer[row * MATRIX_COLS * col * 2]       = s;
+                rgbrec_buffer[(row * MATRIX_COLS * col * 2) + 1] = v;
+            }
+        }
+    }
+}
+
+void rgbrec_read_current_channel(uint8_t channel) {
+    uint32_t offset = 0;
+
+    if (channel >= RGBREC_CHANNEL_NUM) {
+
+        return;
+    }
+
+    offset = (uint32_t)(RGBREC_EECONFIG_OFFSET) + (channel * sizeof(rgbrec_buffer));
+    eeconfig_read_user_datablock(rgbrec_buffer, offset, sizeof(rgbrec_buffer));
+}
+
+bool rgbrec_is_started(void) {
+
+    return (rgbrec_info.state == RGBREC_STATE_ON);
+}
+
+static inline void cycle_rgb_next_color(uint8_t row, uint8_t col) {
+
+    if (p_rgbrec_effects == NULL) {
+
+        return;
+    }
+
+    for (uint8_t index = 0; index < RGBREC_COLOR_NUM; index++) {
+        if (rgbrec_hs_lists[index] == p_rgbrec_effects[row][col]) {
+            index                      = ((index + 1) % RGBREC_COLOR_NUM);
+            p_rgbrec_effects[row][col] = rgbrec_hs_lists[index];
+
+            return;
+        }
+    }
+
+    p_rgbrec_effects[row][col] = rgbrec_hs_lists[0];
+}
+
+bool rgbrec_register_record(uint16_t keycode, keyrecord_t *record) {
+    (void)keycode;
+
+    if (rgbrec_info.state == RGBREC_STATE_ON) {
+        cycle_rgb_next_color(record->event.key.row, record->event.key.col);
+
+        return true;
+    }
+
+    return false;
+}
+
+void eeconfig_init_user_datablock(void) {
+    // Keep defaults in firmware image; persisted user data is updated lazily.
+}
+
+uint8_t find_index(void) {
+
+    for (uint8_t index = 0; index < (sizeof(rgbmatrix_buff) / sizeof(rgbmatrix_buff[0])); index++) {
+        if (rgb_matrix_get_mode() == rgbmatrix_buff[index]) {
+
+            return index;
+        }
+    }
+
+    return 0;
+}
+
+void record_rgbmatrix_increase(uint8_t *last_mode) {
+    uint8_t index;
+
+    index = find_index();
+    if (rgbrec_info.state != RGBREC_STATE_ON) {
+        index = (index + 1) % (sizeof(rgbmatrix_buff) / sizeof(rgbmatrix_buff[0]));
+    }
+    *last_mode = rgbmatrix_buff[index];
+    rgb_matrix_mode(rgbmatrix_buff[index]);
+    record_color_hsv(false);
+}
+
+uint8_t record_color_read_data(void) {
+    uint8_t hs_mode    = find_index();
+    const uint32_t offset = (((uint32_t)CONFINFO_EECONFIG_OFFSET + 4) + hs_mode);
+    uint8_t hs_c;
+    eeconfig_read_user_datablock(&hs_c, offset, 1);
+
+    if (hs_c > RGB_HSV_MAX) {
+        return 0;
+    } else {
+        return hs_c;
+    }
+}
+
+uint8_t record_color_hsv(bool status) {
+    uint8_t temp;
+    uint8_t rgb_hsv_index = record_color_read_data();
+
+    for (uint8_t i = 0; i < (sizeof(sixth_gear_buff) / sizeof(sixth_gear_buff[0])); i++) {
+        if (rgb_matrix_get_mode() == sixth_gear_buff[i]) {
+            temp = RGB_HSV_MAX - 1;
+            break;
+        } else if (i == (sizeof(sixth_gear_buff) / sizeof(sixth_gear_buff[0]) - 1)) {
+            temp = RGB_HSV_MAX;
+        }
+    }
+
+    if (status) {
+        if (rgb_hsv_index != temp)
+            rgb_hsv_index = (rgb_hsv_index + 1);
+        else
+            rgb_hsv_index = 0xFF;
+    } else {
+        if (rgb_hsv_index)
+            rgb_hsv_index = (rgb_hsv_index - 1);
+        else
+            rgb_hsv_index = 0xFF;
+    }
+
+    rgb_matrix_sethsv(rgb_hsvs[rgb_hsv_index][0], rgb_hsvs[rgb_hsv_index][1], rgb_matrix_get_val());
+
+    uint32_t offset = ((uint32_t)CONFINFO_EECONFIG_OFFSET + 4) + find_index();
+    eeconfig_update_user_datablock(&rgb_hsv_index, offset, 1);
+    return rgb_hsv_index;
+}
+
+bool rk_bat_req_flag;
+
+void query(void) {
+    if (rk_bat_req_flag) {
+#ifdef RGBLIGHT_ENABLE
+        for (uint8_t i = 0; i < (RGB_MATRIX_LED_COUNT - RGBLED_NUM); i++) {
+            rgb_matrix_set_color(i, 0, 0, 0);
+        }
+#else
+        rgb_matrix_set_color_all(0x00, 0x00, 0x00);
+#endif
+        for (uint8_t i = 0; i < 10; i++) {
+            uint8_t mi_index[10] = RGB_MATRIX_BAT_INDEX_MAP;
+            if ((i < (*md_getp_bat() / 10)) || (i < 1)) {
+                if (*md_getp_bat() >= (IM_BAT_REQ_LEVEL1_VAL)) {
+                    rgb_matrix_set_color(mi_index[i], IM_BAT_REQ_LEVEL1_COLOR);
+                } else if (*md_getp_bat() >= (IM_BAT_REQ_LEVEL2_VAL)) {
+                    rgb_matrix_set_color(mi_index[i], IM_BAT_REQ_LEVEL2_COLOR);
+                } else {
+                    rgb_matrix_set_color(mi_index[i], IM_BAT_REQ_LEVEL3_COLOR);
+                }
+            } else {
+                rgb_matrix_set_color(mi_index[i], 0x00, 0x00, 0x00);
+            }
+        }
+    }
+}

--- a/keyboards/epomaker/split70/rgb_record/rgb_record.h
+++ b/keyboards/epomaker/split70/rgb_record/rgb_record.h
@@ -1,0 +1,83 @@
+/* Copyright (C) 2023 Westberry Technology Corp., Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <math.h>
+#include "color.h"
+#include "eeprom.h"
+#include "quantum.h"
+#include "wireless.h"
+
+#define HS_GET_H(value) ((uint8_t)(value >> 8))
+#define HS_GET_S(value) ((uint8_t)(value & 0xFF))
+
+/* HSV Color bit[15:8] H  bit[7:0] S */
+#define HS_AZURE        0x8466
+#define HS_BLACK        0x0000
+#define HS_BLUE         0xAAFF
+#define HS_CHARTREUSE   0x40FF
+#define HS_CORAL        0x0BB0
+#define HS_GOLD         0x24FF
+#define HS_GOLDENROD    0x1EDA
+#define HS_GREEN        0x55FF
+#define HS_MAGENTA      0xD5FF
+#define HS_ORANGE       0x15FF
+#define HS_PINK         0xEA80
+#define HS_PURPLE       0xBFFF
+#define HS_RED          0x00FF
+#define HS_CYAN         0x6AFF
+#define HS_TEAL         0x80FF
+#define HS_TURQUOISE    0x7B5A
+#define HS_WHITE        0x0101
+#define HS_YELLOW       0x2BFF
+
+#define LASET_MOD_NO    0xFF
+#define RGB_HSV_MAX     7
+#define ________        HS_BLACK
+
+#ifndef RGB_RECORD_HS_LISTS
+#    define RGB_RECORD_HS_LISTS \
+        {HS_BLACK, HS_RED, HS_GREEN, HS_BLUE, HS_YELLOW, HS_PURPLE, HS_CYAN, HS_WHITE}
+#endif
+
+#define RGB_MATRIX_BAT_VAL      150
+
+#define IM_BAT_REQ_LEVEL1_VAL   50
+#define IM_BAT_REQ_LEVEL1_COLOR 0x00, RGB_MATRIX_BAT_VAL, 0x00
+
+#define IM_BAT_REQ_LEVEL2_VAL   30
+#define IM_BAT_REQ_LEVEL2_COLOR 0x00, RGB_MATRIX_BAT_VAL, 0x00
+
+#define IM_BAT_REQ_LEVEL3_COLOR RGB_MATRIX_BAT_VAL, 0x00, 0x00
+
+void rgbrec_read_current_channel(uint8_t channel);
+void rgbrec_set_close_all(uint8_t h, uint8_t s, uint8_t v);
+void rgbrec_play(uint8_t led_min, uint8_t led_max);
+bool rgbrec_end(uint8_t channel);
+bool rgbrec_start(uint8_t channel);
+bool rgbrec_show(uint8_t channel);
+void rgbrec_init(uint8_t channel);
+bool rgbrec_is_started(void);
+void eeconfig_init_user_datablock(void);
+bool rgbrec_register_record(uint16_t keycode, keyrecord_t *record);
+void record_rgbmatrix_increase(uint8_t *last_mode);
+uint8_t record_color_hsv(bool status);
+void query(void);

--- a/keyboards/epomaker/split70/rgb_record/rgb_record.mk
+++ b/keyboards/epomaker/split70/rgb_record/rgb_record.mk
@@ -1,0 +1,1 @@
+SRC += rgb_record/rgb_record.c

--- a/keyboards/epomaker/split70/split70.c
+++ b/keyboards/epomaker/split70/split70.c
@@ -1,0 +1,1636 @@
+// Copyright 2025 EPOMAKER (@Epomaker)
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include QMK_KEYBOARD_H
+#include "rgb_record/rgb_record.h"
+#include "quantum.h"
+#include "serial_usart.h"
+#ifdef WIRELESS_ENABLE
+#    include "wls/wls.h"
+#    include "wireless.h"
+#    include "usb_main.h"
+#    include "lowpower.h"
+#    include "module.h"
+
+// Add this forward declaration
+void usb_mode_test_report_task(void);
+extern bool im_test_rate_flag;
+#endif
+
+typedef union {
+    uint32_t raw;
+    struct {
+        uint8_t flag : 1;
+        uint8_t devs : 3;
+        uint8_t record_channel : 4;
+        uint8_t record_last_mode;
+        uint8_t last_btdevs : 3;
+        uint8_t dir_flag : 1;
+        uint8_t filp : 1;
+    };
+} confinfo_t;
+confinfo_t confinfo;
+
+typedef struct {
+    bool     active;
+    uint32_t timer;
+    uint32_t interval;
+    uint32_t times;
+    uint8_t  index;
+    RGB      rgb;
+    void (*blink_cb)(uint8_t);
+} hs_rgb_indicator_t;
+
+enum layers {
+    _BL = 0,
+    _FL,
+    _MBL,
+    _MFL,
+};
+
+hs_rgb_indicator_t hs_rgb_indicators[HS_RGB_INDICATOR_COUNT];
+hs_rgb_indicator_t hs_rgb_bat[HS_RGB_BAT_COUNT];
+
+void user_sync_mms_slave_handler(uint8_t in_buflen, const void *in_data, uint8_t out_buflen, void *out_data);
+void rgb_blink_dir(void);
+void hs_reset_settings(void);
+void rgb_matrix_hs_indicator(void);
+void rgb_matrix_hs_indicator_set(uint8_t index, RGB rgb, uint32_t interval, uint8_t times);
+void rgb_matrix_hs_set_remain_time(uint8_t index, uint8_t remain_time);
+
+#define keymap_is_mac_system() ((get_highest_layer(default_layer_state) == _MBL) || (get_highest_layer(default_layer_state) == _MFL))
+#define keymap_is_base_layer() ((get_highest_layer(default_layer_state) == _BL) || (get_highest_layer(default_layer_state) == _FL))
+
+uint32_t        post_init_timer       = 0x00;
+bool            inqbat_flag           = false;
+bool            mac_status            = false;
+bool            charging_state        = false;
+bool            bat_full_flag         = false;
+bool            enable_bat_indicators = true;
+uint32_t        bat_indicator_cnt     = 0;
+static uint32_t ee_clr_timer          = 0;
+bool            test_white_light_flag = false;
+HSV             start_hsv;
+bool            no_record_fg;
+bool            lower_sleep = false;
+uint8_t         pov;
+static bool     im_bat_req_charging_flag = false;
+uint8_t         buff[]                   = {14, 8, 2, 1, 1, 1, 1, 1, 1, 1, 0};
+
+void usart_init(void) {
+    // palSetLineMode(SERIAL_USART_TX_PIN, PAL_MODE_ALTERNATE(SERIAL_USART_TX_PAL_MODE) | PAL_OUTPUT_TYPE_OPENDRAIN);
+    palSetLineMode(SERIAL_USART_TX_PIN, PAL_MODE_ALTERNATE(SERIAL_USART_TX_PAL_MODE) | PAL_OUTPUT_TYPE_PUSHPULL | PAL_OUTPUT_SPEED_HIGHEST);
+    palSetLineMode(SERIAL_USART_RX_PIN, PAL_MODE_ALTERNATE(SERIAL_USART_RX_PAL_MODE) | PAL_OUTPUT_TYPE_PUSHPULL | PAL_OUTPUT_SPEED_HIGHEST);
+}
+
+void eeconfig_confinfo_update(uint32_t raw) {
+    eeconfig_update_kb(raw);
+}
+
+typedef struct _master_to_slave_t {
+    uint8_t cmd;
+    uint8_t body[4];
+} master_to_slave_t;
+
+typedef struct _slave_to_master_t {
+    uint8_t resp;
+    uint8_t body[4];
+} slave_to_master_t;
+
+uint32_t eeconfig_confinfo_read(void) {
+    return eeconfig_read_kb();
+}
+
+void eeconfig_confinfo_default(void) {
+    confinfo.flag             = true;
+    confinfo.record_channel   = 0;
+    confinfo.record_last_mode = 0xff;
+    confinfo.last_btdevs      = 1;
+    confinfo.dir_flag         = 0;
+
+    // #ifdef WIRELESS_ENABLE
+    //     confinfo.devs = DEVS_USB;
+    // #endif
+
+    eeconfig_init_user_datablock();
+    eeconfig_confinfo_update(confinfo.raw);
+
+#ifdef RGBLIGHT_ENABLE
+    rgblight_mode(buff[0]);
+#endif
+}
+
+void master_sync_mms_slave(uint8_t last_mode, uint8_t now_mode, uint8_t reset) {
+    master_to_slave_t m2s = {0};
+    slave_to_master_t s2m = {0};
+    m2s.cmd               = 0x55;
+    m2s.body[0]           = last_mode;
+    m2s.body[1]           = now_mode;
+    m2s.body[2]           = reset;
+    if (transaction_rpc_exec(USER_SYNC_MMS, sizeof(m2s), &m2s, sizeof(s2m), &s2m)) {
+        if (s2m.resp == 0x00)
+            ;
+        dprintf("Slave Sleep OK1\n");
+    } else {
+        dprintf("Slave sync failed1!\n");
+    }
+}
+
+void eeconfig_confinfo_init(void) {
+    confinfo.raw = eeconfig_confinfo_read();
+    if (!confinfo.raw) {
+        eeconfig_confinfo_default();
+    }
+}
+
+void keyboard_post_init_kb(void) {
+#ifdef CONSOLE_ENABLE
+    debug_enable = true;
+#endif
+
+    eeconfig_confinfo_init();
+
+    // Only master controls LED_POWER_EN_PIN/EN2_PIN directly
+    // Slave uses A5/A8 controlled via RPC commands
+    if (is_keyboard_master()) {
+#ifdef LED_POWER_EN_PIN
+        gpio_set_pin_output(LED_POWER_EN_PIN);
+        if (rgb_matrix_get_val() != 0) gpio_write_pin_high(LED_POWER_EN_PIN);
+#endif
+
+#ifdef LED_POWER_EN2_PIN
+        gpio_set_pin_output(LED_POWER_EN2_PIN);
+        if (rgb_matrix_get_val() != 0) gpio_write_pin_high(LED_POWER_EN2_PIN);
+#endif
+    } else {
+        // Slave: initialize A5/A8 directly (not via LED_POWER_EN defines)
+        gpio_set_pin_output(A5);
+        gpio_set_pin_output(A8);
+        if (rgb_matrix_get_val() != 0) {
+            gpio_write_pin_high(A5);
+            gpio_write_pin_high(A8);
+        }
+    }
+
+#ifdef HS_BT_DEF_PIN
+    gpio_set_pin_input_high(HS_BT_DEF_PIN);
+#endif
+
+#ifdef HS_2G4_DEF_PIN
+    gpio_set_pin_input_high(HS_2G4_DEF_PIN);
+#endif
+
+#ifdef USB_POWER_EN_PIN
+    gpio_write_pin_low(USB_POWER_EN_PIN);
+    gpio_set_pin_output(USB_POWER_EN_PIN);
+#endif
+
+#ifdef HS_BAT_CABLE_PIN
+    gpio_set_pin_input(HS_BAT_CABLE_PIN);
+#endif
+
+#ifdef BAT_FULL_PIN
+    gpio_set_pin_input_high(BAT_FULL_PIN);
+#endif
+
+#ifdef WIRELESS_ENABLE
+    wireless_init();
+#    if (!(defined(HS_BT_DEF_PIN) && defined(HS_2G4_DEF_PIN)))
+    wireless_devs_change(!confinfo.devs, confinfo.devs, false);
+#    endif
+    post_init_timer = timer_read32();
+#endif
+
+    keyboard_post_init_user();
+
+    rgbrec_init(confinfo.record_channel);
+
+    start_hsv = rgb_matrix_get_hsv();
+
+#ifdef WIRELESS_ENABLE
+    pov = *md_getp_bat();
+#endif
+    // usart_init();
+    transaction_register_rpc(USER_SYNC_MMS, user_sync_mms_slave_handler);
+}
+
+#ifdef WIRELESS_ENABLE
+
+void usb_power_connect(void) {
+#    ifdef USB_POWER_EN_PIN
+    gpio_write_pin_low(USB_POWER_EN_PIN);
+#    endif
+}
+
+void usb_power_disconnect(void) {
+#    ifdef USB_POWER_EN_PIN
+    gpio_write_pin_high(USB_POWER_EN_PIN);
+#    endif
+}
+
+void suspend_power_down_kb(void) {
+    // Only master controls LED_POWER_EN pins - slave uses A5/A8 via RPC
+    if (is_keyboard_master()) {
+#    ifdef LED_POWER_EN_PIN
+        gpio_write_pin_low(LED_POWER_EN_PIN);
+#    endif
+
+#    ifdef LED_POWER_EN2_PIN
+        gpio_write_pin_low(LED_POWER_EN2_PIN);
+#    endif
+    }
+
+    suspend_power_down_user();
+}
+
+void suspend_wakeup_init_kb(void) {
+    // Give split UART time to stabilize before powering LEDs
+    // This prevents flickering on the slave/right half
+    // wait_ms(50);
+
+    // Clear keyboard state to prevent stuck modifiers
+    // This ensures clean state after wake, especially important
+    // when waking with modifier keys from the slave half
+    // clear_keyboard();
+
+    // Only master controls LED_POWER_EN pins - slave uses A5/A8 via RPC
+    if (is_keyboard_master()) {
+#    ifdef LED_POWER_EN_PIN
+        if (rgb_matrix_get_val() != 0) gpio_write_pin_high(LED_POWER_EN_PIN);
+#    endif
+
+#    ifdef LED_POWER_EN2_PIN
+        if (rgb_matrix_get_val() != 0) gpio_write_pin_high(LED_POWER_EN2_PIN);
+#    endif
+    }
+
+    wireless_devs_change(wireless_get_current_devs(), wireless_get_current_devs(), false);
+    suspend_wakeup_init_user();
+    hs_rgb_blink_set_timer(timer_read32());
+}
+
+void suspend_wakeup_init_user(void) {
+    usart_init();
+    master_to_slave_t m2s = {0};
+    slave_to_master_t s2m = {0};
+    m2s.cmd               = 0xCC;
+    if (transaction_rpc_exec(USER_SYNC_MMS, sizeof(m2s), &m2s, sizeof(s2m), &s2m)) {
+        if (s2m.resp == 0x00) {}
+        dprintf("Slave Sleep OK\n");
+    } else {
+        dprint("Slave sync failed!\n");
+    }
+}
+
+void suspend_power_down_user(void) {
+
+    master_to_slave_t m2s = {0};
+    slave_to_master_t s2m = {0};
+    m2s.cmd               = 0xBB;
+    if (transaction_rpc_exec(USER_SYNC_MMS, sizeof(m2s), &m2s, sizeof(s2m), &s2m)) {
+        if (s2m.resp == 0x00) {}
+        dprintf("Slave Sleep OK\n");
+    } else {
+        dprint("Slave sync failed!\n");
+    }
+
+}
+
+bool lpwr_is_allow_timeout_hook(void) {
+
+    if (wireless_get_current_devs() == DEVS_USB && is_keyboard_master()) {
+        return false;
+    }
+
+    return true;
+}
+
+bool lpwr_is_allow_presleep_hook(void) {
+    extern bool charging_state;
+
+    if (is_keyboard_master()) {
+        master_to_slave_t m2s = {0};
+        slave_to_master_t s2m = {0};
+        m2s.cmd               = 0xAA;
+        m2s.body[0] = lower_sleep;
+        if (transaction_rpc_exec(USER_SYNC_MMS, sizeof(m2s), &m2s, sizeof(s2m), &s2m)) {
+            if (s2m.resp == 0x00) {}
+            dprintf("Slave Sleep OK\n");
+        } else {
+            dprint("Slave sync failed!\n");
+        }
+
+        if (confinfo.devs != DEVS_USB) {
+            palSetLineMode(SERIAL_USART_RX_PIN, PAL_OUTPUT_TYPE_OPENDRAIN);
+            palSetLineMode(SERIAL_USART_TX_PIN, PAL_OUTPUT_TYPE_OPENDRAIN);
+        }
+    }
+
+    if ((wireless_get_current_devs() == DEVS_USB) && (!charging_state)) {
+
+        if (USB_DRIVER.state != USB_STOP) {
+            usb_power_disconnect();
+            usbDisconnectBus(&USBD1);
+            usbStop(&USBD1);
+        }
+    }
+    return true;
+}
+
+void wireless_post_task(void) {
+    // auto switching devs
+    if (post_init_timer && timer_elapsed32(post_init_timer) >= 100) {
+        md_send_devctrl(MD_SND_CMD_DEVCTRL_FW_VERSION);   // get the module fw version.
+        md_send_devctrl(MD_SND_CMD_DEVCTRL_SLEEP_BT_EN);  // timeout 30min to sleep in bt mode, enable
+        md_send_devctrl(MD_SND_CMD_DEVCTRL_SLEEP_2G4_EN); // timeout 30min to sleep in 2.4g mode, enable
+        wireless_devs_change(!confinfo.devs, confinfo.devs, false);
+        post_init_timer = 0x00;
+    }
+#    if defined(HS_BT_DEF_PIN) && defined(HS_2G4_DEF_PIN)
+    hs_mode_scan(false, confinfo.devs, confinfo.last_btdevs);
+#    endif
+}
+
+uint32_t wls_process_long_press(uint32_t trigger_time, void *cb_arg) {
+    uint16_t keycode = *((uint16_t *)cb_arg);
+
+    switch (keycode) {
+        case KC_BT1: {
+            uint8_t mode = confinfo.devs;
+            hs_modeio_detection(true, &mode, confinfo.last_btdevs);
+            if ((mode == hs_bt) || (mode == hs_wireless) || (mode == hs_none)) {
+                wireless_devs_change(wireless_get_current_devs(), DEVS_BT1, true);
+            }
+
+        } break;
+        case KC_BT2: {
+            uint8_t mode = confinfo.devs;
+            hs_modeio_detection(true, &mode, confinfo.last_btdevs);
+            if ((mode == hs_bt) || (mode == hs_wireless) || (mode == hs_none)) {
+                wireless_devs_change(wireless_get_current_devs(), DEVS_BT2, true);
+            }
+        } break;
+        case KC_BT3: {
+            uint8_t mode = confinfo.devs;
+            hs_modeio_detection(true, &mode, confinfo.last_btdevs);
+            if ((mode == hs_bt) || (mode == hs_wireless) || (mode == hs_none)) {
+                wireless_devs_change(wireless_get_current_devs(), DEVS_BT3, true);
+            }
+        } break;
+        case KC_2G4: {
+            uint8_t mode = confinfo.devs;
+            hs_modeio_detection(true, &mode, confinfo.last_btdevs);
+            if ((mode == hs_2g4) || (mode == hs_wireless) || (mode == hs_none)) {
+                wireless_devs_change(wireless_get_current_devs(), DEVS_2G4, true);
+            }
+        } break;
+        case EE_CLR: {
+        } break;
+        default:
+            break;
+    }
+
+    return 0;
+}
+
+bool process_record_wls(uint16_t keycode, keyrecord_t *record) {
+    static uint16_t       keycode_shadow               = 0x00;
+    static deferred_token wls_process_long_press_token = INVALID_DEFERRED_TOKEN;
+
+    keycode_shadow = keycode;
+
+#    ifndef WLS_KEYCODE_PAIR_TIME
+#        define WLS_KEYCODE_PAIR_TIME 3000
+#    endif
+
+#    define WLS_KEYCODE_EXEC(wls_dev)                                                                                          \
+        do {                                                                                                                   \
+            if (record->event.pressed) {                                                                                       \
+                if (wireless_get_current_devs() != wls_dev)                                                                    \
+                    wireless_devs_change(wireless_get_current_devs(), wls_dev, false);                                         \
+                if (wls_process_long_press_token == INVALID_DEFERRED_TOKEN) {                                                  \
+                    wls_process_long_press_token = defer_exec(WLS_KEYCODE_PAIR_TIME, wls_process_long_press, &keycode_shadow); \
+                }                                                                                                              \
+            } else {                                                                                                           \
+                cancel_deferred_exec(wls_process_long_press_token);                                                            \
+                wls_process_long_press_token = INVALID_DEFERRED_TOKEN;                                                         \
+            }                                                                                                                  \
+        } while (false)
+
+    switch (keycode) {
+        case KC_BT1: {
+            uint8_t mode = confinfo.devs;
+            hs_modeio_detection(true, &mode, confinfo.last_btdevs);
+            if ((mode == hs_bt) || (mode == hs_wireless) || (mode == hs_none)) {
+                WLS_KEYCODE_EXEC(DEVS_BT1);
+                hs_rgb_blink_set_timer(timer_read32());
+            }
+
+        } break;
+        case KC_BT2: {
+            uint8_t mode = confinfo.devs;
+            hs_modeio_detection(true, &mode, confinfo.last_btdevs);
+            if ((mode == hs_bt) || (mode == hs_wireless) || (mode == hs_none)) {
+                WLS_KEYCODE_EXEC(DEVS_BT2);
+                hs_rgb_blink_set_timer(timer_read32());
+            }
+        } break;
+        case KC_BT3: {
+            uint8_t mode = confinfo.devs;
+            hs_modeio_detection(true, &mode, confinfo.last_btdevs);
+            if ((mode == hs_bt) || (mode == hs_wireless) || (mode == hs_none)) {
+                WLS_KEYCODE_EXEC(DEVS_BT3);
+                hs_rgb_blink_set_timer(timer_read32());
+            }
+        } break;
+        case KC_2G4: {
+            uint8_t mode = confinfo.devs;
+            hs_modeio_detection(true, &mode, confinfo.last_btdevs);
+            if ((mode == hs_2g4) || (mode == hs_wireless) || (mode == hs_none)) {
+                WLS_KEYCODE_EXEC(DEVS_2G4);
+                hs_rgb_blink_set_timer(timer_read32());
+            }
+        } break;
+
+        default:
+            return true;
+    }
+
+    return false;
+}
+#endif
+
+bool process_record_user_split65(uint16_t keycode, keyrecord_t *record) {
+
+    // Call the user's keymap function first
+    if (!process_record_user(keycode, record)) {
+        return false;
+    }
+
+    if (test_white_light_flag && record->event.pressed) {
+        test_white_light_flag = false;
+        rgb_matrix_set_color_all(0x00, 0x00, 0x00);
+    }
+
+#ifdef WIRELESS_ENABLE
+    if (*md_getp_state() == MD_STATE_CONNECTED) {
+        hs_rgb_blink_set_timer(timer_read32());
+    }
+#endif
+
+    switch (keycode) {
+        case MO(_FL):
+        case MO(_MFL): {
+            if (!record->event.pressed && rgbrec_is_started()) {
+                if (no_record_fg == true) {
+                    no_record_fg = false;
+                    rgbrec_register_record(keycode, record);
+                }
+                no_record_fg = true;
+            }
+            break;
+        }
+
+        case RM_NEXT:
+            break;
+        default: {
+            if (rgbrec_is_started()) {
+                if (!IS_QK_MOMENTARY(keycode) && record->event.pressed) {
+                    rgbrec_register_record(keycode, record);
+
+                    return false;
+                }
+            }
+        } break;
+    }
+
+    return true;
+}
+
+void im_rgblight_increase(void) {
+    HSV            rgb;
+    uint8_t        moude;
+    static uint8_t mode = 0;
+
+    moude = rgblight_get_mode();
+    if (moude == 1) {
+        rgb = rgblight_get_hsv();
+        if (rgb.h == 0 && rgb.s != 0)
+            mode = 3;
+        else
+            mode = 9;
+        switch (rgb.h) {
+            case 40: {
+                mode = 4;
+            } break;
+            case 80: {
+                mode = 5;
+            } break;
+            case 120: {
+                mode = 6;
+            } break;
+            case 160: {
+                mode = 7;
+            } break;
+            case 200: {
+                mode = 8;
+            } break;
+            default:
+                break;
+        }
+    }
+
+    mode++;
+    if (mode == 11) mode = 0;
+    if (mode == 10) {
+        rgb = rgblight_get_hsv();
+        rgblight_sethsv(0, 255, rgb.v);
+        rgblight_disable();
+    } else {
+        rgblight_enable();
+        rgblight_mode(buff[mode]);
+    }
+
+    rgb = rgblight_get_hsv();
+    switch (mode) {
+        case 3: {
+            rgblight_sethsv(0, 255, rgb.v);
+        } break;
+        case 4: {
+            rgblight_sethsv(40, 255, rgb.v);
+        } break;
+        case 5: {
+            rgblight_sethsv(80, 255, rgb.v);
+        } break;
+        case 6: {
+            rgblight_sethsv(120, 255, rgb.v);
+        } break;
+        case 7: {
+            rgblight_sethsv(160, 255, rgb.v);
+        } break;
+        case 8: {
+            rgblight_sethsv(200, 255, rgb.v);
+        } break;
+        case 9: {
+            rgblight_sethsv(0, 0, rgb.v);
+        } break;
+        case 0: {
+            rgblight_set_speed(255);
+        } break;
+        default: {
+            rgblight_set_speed(200);
+        } break;
+    }
+}
+
+uint32_t hs_ct_time;
+RGB      rgb_test_open;
+bool     process_record_kb(uint16_t keycode, keyrecord_t *record) {
+
+    if (process_record_user_split65(keycode, record) != true) {
+        return false;
+    }
+
+#ifdef WIRELESS_ENABLE
+    if (process_record_wls(keycode, record) != true) {
+        return false;
+    }
+#endif
+    switch (keycode) {
+        case KC_F1: {
+            if (confinfo.filp) {
+                if (keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code16(KC_MSEL);
+                    } else {
+                        unregister_code16(KC_MSEL);
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } break;
+        case KC_F2: {
+            if (confinfo.filp) {
+                if (keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code16(KC_VOLD);
+                    } else {
+                        unregister_code16(KC_VOLD);
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } break;
+        case KC_F3: {
+            if (confinfo.filp) {
+                if (keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code16(KC_VOLU);
+                    } else {
+                        unregister_code16(KC_VOLU);
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } break;
+        case KC_F4: {
+            if (confinfo.filp) {
+                if (keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code16(KC_MUTE);
+                    } else {
+                        unregister_code16(KC_MUTE);
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } break;
+        case KC_F5: {
+            if (confinfo.filp) {
+                if (keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code16(KC_MSTP);
+                    } else {
+                        unregister_code16(KC_MSTP);
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } break;
+        case KC_F6: {
+            if (confinfo.filp) {
+                if (keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code16(KC_MPRV);
+                    } else {
+                        unregister_code16(KC_MPRV);
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } break;
+        case KC_F7: {
+            if (confinfo.filp) {
+                if (keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code16(KC_MPLY);
+                    } else {
+                        unregister_code16(KC_MPLY);
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } break;
+        case KC_F8: {
+            if (confinfo.filp) {
+                if (keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code16(KC_MNXT);
+                    } else {
+                        unregister_code16(KC_MNXT);
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } break;
+        case KC_F9: {
+            if (confinfo.filp) {
+                if (keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code16(KC_MAIL);
+                    } else {
+                        unregister_code16(KC_MAIL);
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } break;
+        case KC_F10: {
+            if (confinfo.filp) {
+                if (keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code16(KC_WHOM);
+                    } else {
+                        unregister_code16(KC_WHOM);
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } break;
+        case KC_F11: {
+            if (confinfo.filp) {
+                if (keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code16(KC_CALC);
+                    } else {
+                        unregister_code16(KC_CALC);
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } break;
+        case KC_F12: {
+            if (confinfo.filp) {
+                if (keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code16(KC_WSCH);
+                    } else {
+                        unregister_code16(KC_WSCH);
+                    }
+                    return false;
+                }
+            }
+            return true;
+        } break;
+        case KC_1: {
+            if (confinfo.filp) {
+                if (!keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code(KC_F1);
+                    } else {
+                        unregister_code(KC_F1);
+                    }
+                } else {
+                    if (record->event.pressed) {
+                        register_code(KC_BRID);
+                    } else {
+                        unregister_code(KC_BRID);
+                    }
+                }
+                return false;
+            }
+            return true;
+        } break;
+        case KC_2: {
+            if (confinfo.filp) {
+                if (!keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code(KC_F2);
+                    } else {
+                        unregister_code(KC_F2);
+                    }
+                } else {
+                    if (record->event.pressed) {
+                        register_code(KC_BRIU);
+                    } else {
+                        unregister_code(KC_BRIU);
+                    }
+                }
+                return false;
+            }
+            return true;
+        } break;
+        case KC_3: {
+            if (confinfo.filp) {
+                if (!keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code(KC_F3);
+                    } else {
+                        unregister_code(KC_F3);
+                    }
+                } else {
+                    if (record->event.pressed) {
+                        register_code(KC_LGUI);
+                        register_code(KC_TAB);
+                    } else {
+                        unregister_code(KC_LGUI);
+                        unregister_code(KC_TAB);
+                    }
+                }
+                return false;
+            }
+            return true;
+        } break;
+        case KC_4: {
+            if (confinfo.filp) {
+                if (!keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code(KC_F4);
+                    } else {
+                        unregister_code(KC_F4);
+                    }
+                } else {
+                    if (record->event.pressed) {
+                        register_code(KC_LGUI);
+                        register_code(KC_E);
+                    } else {
+                        unregister_code(KC_LGUI);
+                        unregister_code(KC_E);
+                    }
+                }
+                return false;
+            }
+            return true;
+        } break;
+        case KC_5: {
+            if (confinfo.filp) {
+                if (!keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code(KC_F5);
+                    } else {
+                        unregister_code(KC_F5);
+                    }
+                } else {
+                    if (record->event.pressed) {
+                        rgb_matrix_decrease_val();
+                    }
+                }
+                return false;
+            }
+            return true;
+        } break;
+        case KC_6: {
+            if (confinfo.filp) {
+                if (!keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code(KC_F6);
+                    } else {
+                        unregister_code(KC_F6);
+                    }
+                } else {
+                    if (record->event.pressed) {
+                        rgb_matrix_increase_val();
+                    }
+                }
+                return false;
+            }
+            return true;
+        } break;
+        case KC_7: {
+            if (confinfo.filp) {
+                if (!keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code(KC_F7);
+                    } else {
+                        unregister_code(KC_F7);
+                    }
+                } else {
+                    if (record->event.pressed) {
+                        register_code(KC_MPRV);
+                    } else {
+                        unregister_code(KC_MPRV);
+                    }
+                }
+                return false;
+            }
+            return true;
+        } break;
+        case KC_8: {
+            if (confinfo.filp) {
+                if (!keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code(KC_F8);
+                    } else {
+                        unregister_code(KC_F8);
+                    }
+                } else {
+                    if (record->event.pressed) {
+                        register_code(KC_MPLY);
+                    } else {
+                        unregister_code(KC_MPLY);
+                    }
+                }
+                return false;
+            }
+            return true;
+        } break;
+        case KC_9: {
+            if (confinfo.filp) {
+                if (!keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code(KC_F9);
+                    } else {
+                        unregister_code(KC_F9);
+                    }
+                } else {
+                    if (record->event.pressed) {
+                        register_code(KC_MNXT);
+                    } else {
+                        unregister_code(KC_MNXT);
+                    }
+                }
+                return false;
+            }
+            return true;
+        } break;
+        case KC_0: {
+            if (confinfo.filp) {
+                if (!keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code(KC_F10);
+                    } else {
+                        unregister_code(KC_F10);
+                    }
+                } else {
+                    if (record->event.pressed) {
+                        register_code(KC_MUTE);
+                    } else {
+                        unregister_code(KC_MUTE);
+                    }
+                }
+                return false;
+            }
+            return true;
+        } break;
+        case KC_MINS: {
+            if (confinfo.filp) {
+                if (!keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code(KC_F11);
+                    } else {
+                        unregister_code(KC_F11);
+                    }
+                } else {
+                    if (record->event.pressed) {
+                        register_code(KC_VOLD);
+                    } else {
+                        unregister_code(KC_VOLD);
+                    }
+                }
+                return false;
+            }
+            return true;
+        } break;
+        case KC_EQL: {
+            if (confinfo.filp) {
+                if (!keymap_is_mac_system()) {
+                    if (record->event.pressed) {
+                        register_code(KC_F12);
+                    } else {
+                        unregister_code(KC_F12);
+                    }
+                } else {
+                    if (record->event.pressed) {
+                        register_code(KC_VOLU);
+                    } else {
+                        unregister_code(KC_VOLU);
+                    }
+                }
+                return false;
+            }
+            return true;
+        } break;
+        case KC_FILP: {
+            if (record->event.pressed) {
+                confinfo.filp = !confinfo.filp;
+                eeconfig_confinfo_update(confinfo.raw);
+            }
+            return false;
+        } break;
+        case KC_BATQ: {
+            if (record->event.pressed) {
+                im_bat_req_charging_flag = true;
+            } else {
+                im_bat_req_charging_flag = false;
+            }
+        } break;
+        case QK_BOOT: {
+            if (record->event.pressed) {
+                dprintf("into boot!!!\r\n");
+                eeconfig_disable();
+                bootloader_jump();
+            }
+        } break;
+
+        case NK_TOGG: {
+            if (rgbrec_is_started()) {
+                return false;
+            }
+            if (record->event.pressed) {
+                rgb_matrix_hs_indicator_set(0xFF, (RGB){0x00, 0x6E, 0x00}, 250, 1);
+            }
+        } break;
+        case RL_MOD: {
+            if (rgbrec_is_started()) {
+                return false;
+            }
+            if (record->event.pressed) {
+                im_rgblight_increase();
+            }
+
+            return false;
+        } break;
+        case EE_CLR: {
+            if (record->event.pressed) {
+                ee_clr_timer = timer_read32();
+            } else {
+                ee_clr_timer = 0;
+            }
+
+            return false;
+        } break;
+        case RM_SPDU: {
+            if (record->event.pressed) {
+                if (rgb_matrix_get_speed() >= 215) {
+                    rgb_blink_dir();
+                }
+            }
+        } break;
+        case RM_SPDD: {
+            if (record->event.pressed) {
+                if (rgb_matrix_get_speed() <= 95) {
+                    rgb_blink_dir();
+                }
+            }
+        } break;
+        case RM_VALU: {
+            if (record->event.pressed) {
+                rgb_matrix_enable();
+                if (is_keyboard_master()) {
+                    gpio_write_pin_high(LED_POWER_EN_PIN);
+                    gpio_write_pin_high(LED_POWER_EN2_PIN);
+                }
+                if (rgb_matrix_get_speed() >= 120) {
+                    rgb_blink_dir();
+                }
+            }
+        } break;
+        case RM_VALD: {
+            if (record->event.pressed) {
+                if (rgb_matrix_get_val() <= RGB_MATRIX_VAL_STEP) {
+                    if (is_keyboard_master()) {
+                        gpio_write_pin_low(LED_POWER_EN_PIN);
+                        gpio_write_pin_low(LED_POWER_EN2_PIN);
+                    }
+                    for (uint8_t i = 0; i < RGB_MATRIX_LED_COUNT; i++) {
+                        rgb_matrix_set_color(i, 0, 0, 0);
+                    }
+                }
+                if (rgb_matrix_get_speed() <= 30) {
+                    rgb_blink_dir();
+                }
+            }
+        } break;
+
+        case TO(_BL): {
+            if (record->event.pressed) {
+                rgb_matrix_hs_set_remain_time(HS_RGB_BLINK_INDEX_MAC, 0);
+                rgb_matrix_hs_indicator_set(HS_RGB_BLINK_INDEX_WIN, (RGB){RGB_WHITE}, 250, 3);
+                if (keymap_is_mac_system()) {
+                    set_single_persistent_default_layer(_BL);
+                    layer_move(0);
+                }
+            }
+
+            return false;
+        } break;
+        case TO(_MBL): {
+            if (record->event.pressed) {
+                rgb_matrix_hs_set_remain_time(HS_RGB_BLINK_INDEX_WIN, 0);
+                rgb_matrix_hs_indicator_set(HS_RGB_BLINK_INDEX_MAC, (RGB){RGB_WHITE}, 250, 3);
+                if (!keymap_is_mac_system()) {
+                    set_single_persistent_default_layer(_MBL);
+                    layer_move(0);
+                }
+            }
+
+            return false;
+        } break;
+
+        case RM_NEXT: {
+            if (record->event.pressed) {
+                uint8_t mode = rgb_matrix_get_mode();
+                if (mode == 29) {
+                    rgb_matrix_mode(31);
+                    return false;
+                }
+            }
+            return true;
+
+            return false;
+        } break;
+        case KC_LCMD: {
+            if (keymap_is_mac_system()) {
+                if (keymap_config.no_gui && !rgbrec_is_started()) {
+                    if (record->event.pressed) {
+                        register_code16(KC_LCMD);
+                    } else {
+                        unregister_code16(KC_LCMD);
+                    }
+                }
+            }
+
+            return true;
+        } break;
+        case KC_RCMD: {
+            if (keymap_is_mac_system()) {
+                if (keymap_config.no_gui && !rgbrec_is_started()) {
+                    if (record->event.pressed) {
+                        register_code16(KC_RCMD);
+                    } else {
+                        unregister_code16(KC_RCMD);
+                    }
+                }
+            }
+
+            return true;
+        } break;
+#ifdef WIRELESS_ENABLE
+        case HS_BATQ: {
+            extern bool rk_bat_req_flag;
+            rk_bat_req_flag = (confinfo.devs != DEVS_USB) && record->event.pressed;
+            return false;
+        } break;
+#endif
+
+        default:
+            break;
+    }
+
+    return true;
+}
+
+void housekeeping_task_kb(void) { // loop
+
+    // Came from wireless.c
+    if (wireless_get_current_devs() == DEVS_USB && im_test_rate_flag) usb_mode_test_report_task();
+        wireless_task();
+
+#ifdef WIRELESS_ENABLE
+    uint8_t         hs_now_mode;
+    static uint32_t hs_current_time;
+
+    charging_state = gpio_read_pin(HS_BAT_CABLE_PIN);
+
+    bat_full_flag = gpio_read_pin(BAT_FULL_PIN);
+
+    if (charging_state && (bat_full_flag)) {
+        hs_now_mode = MD_SND_CMD_DEVCTRL_CHARGING_DONE;
+    } else if (charging_state) {
+        hs_now_mode = MD_SND_CMD_DEVCTRL_CHARGING;
+    } else {
+        hs_now_mode = MD_SND_CMD_DEVCTRL_CHARGING_STOP;
+    }
+
+    if (!hs_current_time || timer_elapsed32(hs_current_time) > 1000) {
+        hs_current_time = timer_read32();
+        md_send_devctrl(hs_now_mode);
+        md_send_devctrl(MD_SND_CMD_DEVCTRL_INQVOL);
+    }
+#endif
+
+    if (is_keyboard_master()) {
+        static uint32_t last_sync = 0;
+        if (timer_elapsed32(last_sync) > 2000) {
+            last_sync = timer_read32();
+#ifdef WIRELESS_ENABLE
+            pov = *md_getp_bat();
+            master_sync_mms_slave(wireless_get_current_devs(), wireless_get_current_devs(), pov);
+#endif
+        }
+    }
+
+    // Call the user-level function at the end
+    housekeeping_task_user();
+}
+
+#ifdef RGB_MATRIX_ENABLE
+
+#    ifdef WIRELESS_ENABLE
+bool     wls_rgb_indicator_reset    = false;
+uint32_t wls_rgb_indicator_timer    = 0x00;
+uint32_t wls_rgb_indicator_interval = 0;
+uint32_t wls_rgb_indicator_times    = 0;
+uint32_t wls_rgb_indicator_index    = 0;
+RGB      wls_rgb_indicator_rgb      = {0};
+
+void rgb_matrix_wls_indicator_set(uint8_t index, RGB rgb, uint32_t interval, uint8_t times) {
+    wls_rgb_indicator_timer = timer_read32();
+
+    wls_rgb_indicator_index    = index;
+    wls_rgb_indicator_interval = interval;
+    wls_rgb_indicator_times    = times * 2;
+    wls_rgb_indicator_rgb      = rgb;
+}
+
+void wireless_devs_change_kb(uint8_t old_devs, uint8_t new_devs, bool reset) {
+    wls_rgb_indicator_reset = reset;
+
+    if (confinfo.devs != wireless_get_current_devs()) {
+        confinfo.devs = wireless_get_current_devs();
+        if (confinfo.devs > 0 && confinfo.devs < 4) confinfo.last_btdevs = confinfo.devs;
+        eeconfig_confinfo_update(confinfo.raw);
+    }
+
+    switch (new_devs) {
+        case DEVS_BT1: {
+            if (reset) {
+                rgb_matrix_wls_indicator_set(HS_RGB_BLINK_INDEX_BT1, (RGB){HS_LBACK_COLOR_BT1}, 200, 1);
+            } else {
+                rgb_matrix_wls_indicator_set(HS_RGB_BLINK_INDEX_BT1, (RGB){HS_PAIR_COLOR_BT1}, 500, 1);
+            }
+        } break;
+        case DEVS_BT2: {
+            if (reset) {
+                rgb_matrix_wls_indicator_set(HS_RGB_BLINK_INDEX_BT2, (RGB){HS_LBACK_COLOR_BT2}, 200, 1);
+            } else {
+                rgb_matrix_wls_indicator_set(HS_RGB_BLINK_INDEX_BT2, (RGB){HS_PAIR_COLOR_BT2}, 500, 1);
+            }
+        } break;
+        case DEVS_BT3: {
+            if (reset) {
+                rgb_matrix_wls_indicator_set(HS_RGB_BLINK_INDEX_BT3, (RGB){HS_LBACK_COLOR_BT3}, 200, 1);
+            } else {
+                rgb_matrix_wls_indicator_set(HS_RGB_BLINK_INDEX_BT3, (RGB){HS_PAIR_COLOR_BT3}, 500, 1);
+            }
+        } break;
+        case DEVS_BT4: {
+            if (reset) {
+                rgb_matrix_wls_indicator_set(41, (RGB){RGB_BLUE}, 200, 1);
+            } else {
+                rgb_matrix_wls_indicator_set(41, (RGB){RGB_BLUE}, 500, 1);
+            }
+        } break;
+        case DEVS_BT5: {
+            if (reset) {
+                rgb_matrix_wls_indicator_set(42, (RGB){RGB_BLUE}, 200, 1);
+            } else {
+                rgb_matrix_wls_indicator_set(42, (RGB){RGB_BLUE}, 500, 1);
+            }
+        } break;
+        case DEVS_2G4: {
+            if (reset) {
+                rgb_matrix_wls_indicator_set(HS_RGB_BLINK_INDEX_2G4, (RGB){HS_LBACK_COLOR_2G4}, 200, 1);
+            } else {
+                rgb_matrix_wls_indicator_set(HS_RGB_BLINK_INDEX_2G4, (RGB){HS_LBACK_COLOR_2G4}, 500, 1);
+            }
+        } break;
+        default:
+            break;
+    }
+}
+
+bool rgb_matrix_wls_indicator_cb(void) {
+    if (*md_getp_state() != MD_STATE_CONNECTED) {
+        wireless_devs_change_kb(wireless_get_current_devs(), wireless_get_current_devs(), wls_rgb_indicator_reset);
+        return true;
+    }
+
+    // refresh led
+    led_wakeup();
+
+    return false;
+}
+
+void rgb_matrix_wls_indicator(void) {
+    if (wls_rgb_indicator_timer) {
+        if (timer_elapsed32(wls_rgb_indicator_timer) >= wls_rgb_indicator_interval) {
+            wls_rgb_indicator_timer = timer_read32();
+
+            if (wls_rgb_indicator_times) {
+                wls_rgb_indicator_times--;
+            }
+
+            if (wls_rgb_indicator_times <= 0) {
+                wls_rgb_indicator_timer = 0x00;
+                if (rgb_matrix_wls_indicator_cb() != true) {
+                    return;
+                }
+            }
+        }
+
+        if (wls_rgb_indicator_times % 2) {
+            rgb_matrix_set_color(wls_rgb_indicator_index, wls_rgb_indicator_rgb.r, wls_rgb_indicator_rgb.g, wls_rgb_indicator_rgb.b);
+        } else {
+            rgb_matrix_set_color(wls_rgb_indicator_index, 0x00, 0x00, 0x00);
+        }
+    }
+}
+
+void rgb_matrix_hs_bat_set(uint8_t index, RGB rgb, uint32_t interval, uint8_t times) {
+    for (int i = 0; i < HS_RGB_BAT_COUNT; i++) {
+        if (!hs_rgb_bat[i].active) {
+            hs_rgb_bat[i].active   = true;
+            hs_rgb_bat[i].timer    = timer_read32();
+            hs_rgb_bat[i].interval = interval;
+            hs_rgb_bat[i].times    = times * 2;
+            hs_rgb_bat[i].index    = index;
+            hs_rgb_bat[i].rgb      = rgb;
+            break;
+        }
+    }
+}
+
+void rgb_matrix_hs_bat(void) {
+    for (int i = 0; i < HS_RGB_BAT_COUNT; i++) {
+        if (hs_rgb_bat[i].active) {
+            if (timer_elapsed32(hs_rgb_bat[i].timer) >= hs_rgb_bat[i].interval) {
+                hs_rgb_bat[i].timer = timer_read32();
+
+                if (hs_rgb_bat[i].times) {
+                    hs_rgb_bat[i].times--;
+                }
+
+                if (hs_rgb_bat[i].times <= 0) {
+                    hs_rgb_bat[i].active = false;
+                    hs_rgb_bat[i].timer  = 0x00;
+                }
+            }
+
+            if (hs_rgb_bat[i].times % 2) {
+                rgb_matrix_set_color(hs_rgb_bat[i].index, hs_rgb_bat[i].rgb.r, hs_rgb_bat[i].rgb.g, hs_rgb_bat[i].rgb.b);
+            } else {
+                rgb_matrix_set_color(hs_rgb_bat[i].index, 0x00, 0x00, 0x00);
+            }
+        }
+    }
+}
+bool temp,im_test_rate_flag;
+void bat_indicators(void) {
+    static uint32_t battery_process_time = 0;
+
+    if (!is_keyboard_master())  {
+        return;
+    }
+
+    if (charging_state && (bat_full_flag)) {
+        battery_process_time = 0;
+        if (im_bat_req_charging_flag) rgb_matrix_set_color(HS_MATRIX_BLINK_INDEX_BAT, 0xFF, 0x00, 0x00);
+    } else if (charging_state) {
+        battery_process_time = 0;
+        if (im_bat_req_charging_flag) rgb_matrix_set_color(HS_MATRIX_BLINK_INDEX_BAT, 0x00, 0xFF, 0x00);
+    } else if (*md_getp_bat() <= BATTERY_CAPACITY_LOW) {
+        // was 250, changing to 30000 to blink every 30 seconds instead of 4 times a second
+        rgb_matrix_hs_bat_set(HS_MATRIX_BLINK_INDEX_BAT, (RGB){0xFF, 0x00, 0x00}, 30000, 1);
+
+        if (*md_getp_bat() <= BATTERY_CAPACITY_STOP) {
+            if (!battery_process_time) {
+                battery_process_time = timer_read32();
+            }
+
+            if (battery_process_time && timer_elapsed32(battery_process_time) > 60000) {
+                battery_process_time = 0;
+                lower_sleep          = true;
+                lpwr_set_timeout_manual(true);
+            }
+        }
+    } else {
+        battery_process_time = 0;
+    }
+}
+
+#    endif
+
+#endif
+
+void rgb_blink_dir(void) {
+    rgb_matrix_hs_indicator_set(54, (RGB){0, 0, 0}, 250, 1);
+    rgb_matrix_hs_indicator_set(66, (RGB){0, 0, 0}, 250, 1);
+    rgb_matrix_hs_indicator_set(67, (RGB){0, 0, 0}, 250, 1);
+    rgb_matrix_hs_indicator_set(65, (RGB){0, 0, 0}, 250, 1);
+}
+
+bool hs_reset_settings_user(void) {
+    rgb_matrix_hs_indicator_set(0xFF, (RGB){0x10, 0x10, 0x10}, 250, 3);
+
+    return true;
+}
+
+void nkr_indicators_hook(uint8_t index) {
+    if ((hs_rgb_indicators[index].rgb.r == 0x6E) && (hs_rgb_indicators[index].rgb.g == 0x00) && (hs_rgb_indicators[index].rgb.b == 0x00)) {
+        rgb_matrix_hs_indicator_set(0xFF, (RGB){0x6E, 0x00, 0x00}, 250, 1);
+
+    } else if ((hs_rgb_indicators[index].rgb.r == 0x00) && (hs_rgb_indicators[index].rgb.g == 0x6E) && (hs_rgb_indicators[index].rgb.b == 0x00)) {
+        rgb_matrix_hs_indicator_set(0xFF, (RGB){0x00, 0x00, 0x6F}, 250, 1);
+    }
+}
+
+void rgb_matrix_hs_indicator_set(uint8_t index, RGB rgb, uint32_t interval, uint8_t times) {
+    for (int i = 0; i < HS_RGB_INDICATOR_COUNT; i++) {
+        if (!hs_rgb_indicators[i].active) {
+            hs_rgb_indicators[i].active   = true;
+            hs_rgb_indicators[i].timer    = timer_read32();
+            hs_rgb_indicators[i].interval = interval;
+            hs_rgb_indicators[i].times    = times * 2;
+            hs_rgb_indicators[i].index    = index;
+            hs_rgb_indicators[i].rgb      = rgb;
+            if (index != 0xFF)
+                hs_rgb_indicators[i].blink_cb = NULL;
+            else {
+                hs_rgb_indicators[i].blink_cb = nkr_indicators_hook;
+            }
+            break;
+        }
+    }
+}
+
+void rgb_matrix_hs_set_remain_time(uint8_t index, uint8_t remain_time) {
+    for (int i = 0; i < HS_RGB_INDICATOR_COUNT; i++) {
+        if (hs_rgb_indicators[i].index == index) {
+            hs_rgb_indicators[i].times  = 0;
+            hs_rgb_indicators[i].active = false;
+            break;
+        }
+    }
+}
+
+void rgb_matrix_hs_indicator(void) {
+    for (int i = 0; i < HS_RGB_INDICATOR_COUNT; i++) {
+        if (hs_rgb_indicators[i].active) {
+            if (timer_elapsed32(hs_rgb_indicators[i].timer) >= hs_rgb_indicators[i].interval) {
+                hs_rgb_indicators[i].timer = timer_read32();
+
+                if (hs_rgb_indicators[i].times) {
+                    hs_rgb_indicators[i].times--;
+                }
+
+                if (hs_rgb_indicators[i].times <= 0) {
+                    hs_rgb_indicators[i].active = false;
+                    hs_rgb_indicators[i].timer  = 0x00;
+                    if (hs_rgb_indicators[i].blink_cb != NULL) hs_rgb_indicators[i].blink_cb(i);
+                    continue;
+                }
+            }
+
+            if ((hs_rgb_indicators[i].times % 2)) {
+                if (hs_rgb_indicators[i].index == 0xFF) {
+                    rgb_matrix_set_color_all(hs_rgb_indicators[i].rgb.r, hs_rgb_indicators[i].rgb.g, hs_rgb_indicators[i].rgb.b);
+                } else {
+                    rgb_matrix_set_color(hs_rgb_indicators[i].index, hs_rgb_indicators[i].rgb.r, hs_rgb_indicators[i].rgb.g, hs_rgb_indicators[i].rgb.b);
+                }
+            } else {
+                if (hs_rgb_indicators[i].index == 0xFF) {
+                    rgb_matrix_set_color_all(0x00, 0x00, 0x00);
+                } else {
+                    rgb_matrix_set_color(hs_rgb_indicators[i].index, 0x00, 0x00, 0x00);
+                }
+            }
+        }
+    }
+}
+
+bool rgb_matrix_indicators_advanced_kb(uint8_t led_min, uint8_t led_max) {
+    if (test_white_light_flag) {
+        RGB rgb_test_open = hsv_to_rgb((HSV){.h = 0, .s = 0, .v = RGB_MATRIX_VAL_STEP * 5});
+        rgb_matrix_set_color_all(rgb_test_open.r, rgb_test_open.g, rgb_test_open.b);
+
+        return false;
+    }
+#ifdef RGBLIGHT_ENABLE
+    if (rgb_matrix_indicators_advanced_user(led_min, led_max) != true) {
+        return false;
+    }
+#endif
+
+    if (ee_clr_timer && timer_elapsed32(ee_clr_timer) > 3000) {
+        hs_reset_settings();
+        ee_clr_timer = 0;
+    }
+
+    if (host_keyboard_led_state().caps_lock) rgb_matrix_set_color(HS_RGB_INDEX_CAPS, 0x20, 0x20, 0x20);
+
+    if (!keymap_is_mac_system() && keymap_config.no_gui) rgb_matrix_set_color(HS_RGB_INDEX_WIN_LOCK, 0x20, 0x20, 0x20);
+
+#ifdef RGBLIGHT_ENABLE
+    if (rgb_matrix_indicators_advanced_rgblight(led_min, led_max) != true) {
+        return false;
+    }
+#endif
+
+#ifdef WIRELESS_ENABLE
+    rgb_matrix_wls_indicator();
+
+    if (enable_bat_indicators && !inqbat_flag && !rgbrec_is_started()) {
+        rgb_matrix_hs_bat();
+        bat_indicators();
+        bat_indicator_cnt = timer_read32();
+    }
+
+    if (!enable_bat_indicators) {
+        if (timer_elapsed32(bat_indicator_cnt) > 2000) {
+            enable_bat_indicators = true;
+            bat_indicator_cnt     = timer_read32();
+        }
+    }
+
+#endif
+
+    rgb_matrix_hs_indicator();
+    if (confinfo.filp) rgb_matrix_set_color(32, RGB_MATRIX_MAXIMUM_BRIGHTNESS, RGB_MATRIX_MAXIMUM_BRIGHTNESS, RGB_MATRIX_MAXIMUM_BRIGHTNESS);
+    query();
+    return true;
+}
+
+void hs_reset_settings(void) {
+    if (is_keyboard_master()) {
+        master_to_slave_t m2s = {0};
+        slave_to_master_t s2m = {0};
+        m2s.cmd               = 0xDD;
+        if (transaction_rpc_exec(USER_SYNC_MMS, sizeof(m2s), &m2s, sizeof(s2m), &s2m)) {
+            if (s2m.resp == 0x00) {
+            }
+            dprintf("Slave Sleep OK\n");
+        } else {
+            dprintf("Slave sync failed!\n");
+        }
+    }
+    enable_bat_indicators = false;
+    eeconfig_init();
+    eeconfig_update_rgb_matrix_default();
+
+#ifdef RGBLIGHT_ENABLE
+    extern void rgblight_init(void);
+    is_rgblight_initialized = false;
+    rgblight_init();
+    eeconfig_update_rgblight_default();
+    rgblight_enable();
+#endif
+
+    eeconfig_read_keymap(&keymap_config);
+
+#if defined(NKRO_ENABLE) && defined(FORCE_NKRO)
+    keymap_config.nkro = 0;
+    eeconfig_update_keymap(&keymap_config);
+#endif
+
+    // #if defined(WIRELESS_ENABLE)
+    //     wireless_devs_change(wireless_get_current_devs(), DEVS_USB, false);
+    // #endif
+
+    if (hs_reset_settings_user() != true) {
+        return;
+    }
+#ifdef WIRELESS_ENABLE
+    hs_rgb_blink_set_timer(timer_read32());
+#endif
+    keyboard_post_init_kb();
+}
+
+void lpwr_wakeup_hook(void) {
+#ifdef WIRELESS_ENABLE
+    hs_mode_scan(false, confinfo.devs, confinfo.last_btdevs);
+#endif
+
+    // Delay to ensure split communication is ready before LED power changes
+    // Prevents flickering on the slave/right half during wake from deep sleep
+    wait_ms(50);
+
+    if (is_keyboard_master()) {
+        // Master controls its LED pins via LED_POWER_EN defines
+        if (rgb_matrix_get_val() != 0) {
+            gpio_write_pin_high(LED_POWER_EN_PIN);
+            gpio_write_pin_high(LED_POWER_EN2_PIN);
+        } else {
+            gpio_write_pin_low(LED_POWER_EN_PIN);
+            gpio_write_pin_low(LED_POWER_EN2_PIN);
+        }
+    } else {
+        // Slave controls A5/A8 directly (not via LED_POWER_EN defines)
+        if (rgb_matrix_get_val() != 0) {
+            gpio_write_pin_high(A5);
+            gpio_write_pin_high(A8);
+        } else {
+            gpio_write_pin_low(A5);
+            gpio_write_pin_low(A8);
+        }
+    }
+}
+
+void user_sync_mms_slave_handler(uint8_t in_buflen, const void* in_data, uint8_t out_buflen, void* out_data){
+    const master_to_slave_t *m2s = (const master_to_slave_t*)in_data;
+    slave_to_master_t *s2m = (slave_to_master_t*)out_data;
+
+    switch(m2s->cmd)
+    {
+        case 0x55:  //sync multimode
+            wireless_devs_change(m2s->body[0], m2s->body[1], false);
+            s2m->resp = 0x00;
+        break;
+        case 0xAA:
+            if (confinfo.devs != DEVS_USB) {
+                palSetLineMode(SERIAL_USART_RX_PIN, PAL_OUTPUT_TYPE_OPENDRAIN);
+                palSetLineMode(SERIAL_USART_TX_PIN, PAL_OUTPUT_TYPE_OPENDRAIN);
+            }
+            s2m->resp = 0x00;
+            lower_sleep = m2s->body[0];
+            lpwr_set_timeout_manual(true);
+            break;
+        case 0xBB:
+
+            gpio_write_pin_low(A5);
+            gpio_write_pin_low(A8);
+            s2m->resp = 0x00;
+            break;
+        case 0xCC:
+            gpio_write_pin_high(A5);
+            gpio_write_pin_high(A8);
+            s2m->resp = 0x00;
+            break;
+        case 0xDD:
+            hs_reset_settings();
+            s2m->resp = 0x00;
+            break;
+        default :break;
+    }
+}

--- a/keyboards/epomaker/split70/wls/wls.c
+++ b/keyboards/epomaker/split70/wls/wls.c
@@ -1,0 +1,213 @@
+#include "wls.h"
+
+static ioline_t col_pins[MATRIX_COLS] = MATRIX_COL_PINS;
+static ioline_t col_pins_r[MATRIX_COLS] = MATRIX_COL_PINS_RIGHT;
+
+bool hs_modeio_detection(bool update, uint8_t *mode, uint8_t lsat_btdev) {
+    static uint32_t scan_timer = 0x00;
+
+    if ((update != true) && (timer_elapsed32(scan_timer) <= (HS_MODEIO_DETECTION_TIME))) {
+        return false;
+    }
+    scan_timer = timer_read32();
+#if defined(HS_BT_DEF_PIN) && defined(HS_2G4_DEF_PIN)
+    uint8_t now_mode         = 0x00;
+    uint8_t hs_mode          = 0x00;
+    static uint8_t last_mode = 0x00;
+    bool sw_mode             = false;
+    now_mode                 = (HS_GET_MODE_PIN(HS_USB_PIN_STATE) ? 3 : (HS_GET_MODE_PIN(HS_BT_PIN_STATE) ? 1 : ((HS_GET_MODE_PIN(HS_2G4_PIN_STATE) ? 2 : 0))));
+    hs_mode                  = (*mode >= DEVS_BT1 && *mode <= DEVS_BT5) ? 1 : ((*mode == DEVS_2G4) ? 2 : ((*mode == DEVS_USB) ? 3 : 0));
+    sw_mode                  = ((update || (last_mode == now_mode)) && (hs_mode != now_mode)) ? true : false;
+    last_mode                = now_mode;
+
+    switch (now_mode) {
+        case 1:
+            *mode = hs_bt;
+            if (sw_mode) {
+                wireless_devs_change(wireless_get_current_devs(), lsat_btdev, false);
+            }
+            break;
+        case 2:
+            *mode = hs_2g4;
+            if (sw_mode) {
+                wireless_devs_change(wireless_get_current_devs(), DEVS_2G4, false);
+            }
+            break;
+        case 3:
+            *mode = hs_usb;
+            if (sw_mode)
+                wireless_devs_change(wireless_get_current_devs(), DEVS_USB, false);
+
+            break;
+        default:
+            break;
+    }
+
+    if (sw_mode) {
+        hs_rgb_blink_set_timer(timer_read32());
+        suspend_wakeup_init();
+        return true;
+    }
+#else
+    *mode = hs_none;
+#endif
+
+    return false;
+}
+
+static uint32_t hs_linker_rgb_timer = 0x00;
+
+bool hs_mode_scan(bool update, uint8_t moude, uint8_t lsat_btdev) {
+
+    if (hs_modeio_detection(update, &moude, lsat_btdev)) {
+
+        return true;
+    }
+    hs_rgb_blink_hook();
+    return false;
+}
+
+void hs_rgb_blink_set_timer(uint32_t time) {
+    hs_linker_rgb_timer = time;
+}
+
+uint32_t hs_rgb_blink_get_timer(void) {
+    return hs_linker_rgb_timer;
+}
+
+bool hs_rgb_blink_hook() {
+    static uint8_t last_status;
+
+    if (!is_keyboard_master())  {
+        return false;
+    }
+
+    if (last_status != *md_getp_state()) {
+        last_status = *md_getp_state();
+        hs_rgb_blink_set_timer(0x00);
+    }
+
+    switch (*md_getp_state()) {
+        case MD_STATE_NONE: {
+            hs_rgb_blink_set_timer(0x00);
+        } break;
+
+        case MD_STATE_DISCONNECTED:
+            if (hs_rgb_blink_get_timer() == 0x00) {
+                hs_rgb_blink_set_timer(timer_read32());
+                extern void wireless_devs_change_kb(uint8_t old_devs, uint8_t new_devs, bool reset);
+                wireless_devs_change_kb(wireless_get_current_devs(), wireless_get_current_devs(), false);
+            } else {
+                if (timer_elapsed32(hs_rgb_blink_get_timer()) >= HS_LBACK_TIMEOUT) {
+                    hs_rgb_blink_set_timer(timer_read32());
+                    md_send_devctrl(MD_SND_CMD_DEVCTRL_USB);
+                    wait_ms(200);
+                    lpwr_set_timeout_manual(true);
+                }
+            }
+        case MD_STATE_CONNECTED:
+            if (hs_rgb_blink_get_timer() == 0x00) {
+                hs_rgb_blink_set_timer(timer_read32());
+            } else {
+                if (timer_elapsed32(hs_rgb_blink_get_timer()) >= HS_SLEEP_TIMEOUT) {
+                    hs_rgb_blink_set_timer(timer_read32());
+                    lpwr_set_timeout_manual(true);
+                }
+            }
+        default:
+            break;
+    }
+    return true;
+}
+
+void lpwr_exti_init_hook(void) {
+
+#ifdef HS_BT_DEF_PIN
+    if (is_keyboard_master()) {
+    gpio_set_pin_input_high(HS_BT_DEF_PIN);
+    waitInputPinDelay();
+    palEnableLineEvent(HS_BT_DEF_PIN, PAL_EVENT_MODE_BOTH_EDGES);
+    }
+#endif
+
+#ifdef HS_2G4_DEF_PIN
+    if (is_keyboard_master()) {
+    gpio_set_pin_input_high(HS_2G4_DEF_PIN);
+    waitInputPinDelay();
+    palEnableLineEvent(HS_2G4_DEF_PIN, PAL_EVENT_MODE_BOTH_EDGES);
+    }
+#endif
+
+    if (lower_sleep) {
+#if DIODE_DIRECTION == ROW2COL
+        for (uint8_t i = 0; i < ARRAY_SIZE(col_pins); i++) {
+            if (col_pins[i] != NO_PIN) {
+                gpio_set_pin_output(col_pins[i]);
+                gpio_write_pin_high(col_pins[i]);
+            }
+        }
+
+    #if defined(MATRIX_ROW_PINS_RIGHT) && defined(MATRIX_COL_PINS_RIGHT)
+        for (uint8_t i = 0; i < ARRAY_SIZE(col_pins_r); i++) {
+            if (col_pins_r[i] != NO_PIN) {
+                gpio_set_pin_output(col_pins_r[i]);
+                gpio_write_pin_high(col_pins_r[i]);
+            }
+        }
+    #endif
+#endif
+    }
+    gpio_set_pin_input(HS_BAT_CABLE_PIN);
+    waitInputPinDelay();
+    palEnableLineEvent(HS_BAT_CABLE_PIN, PAL_EVENT_MODE_RISING_EDGE);
+}
+
+void palcallback_cb(uint8_t line) {
+    switch (line) {
+        case PAL_PAD(HS_BAT_CABLE_PIN): {
+            lpwr_set_sleep_wakeupcd(LPWR_WAKEUP_CABLE);
+        } break;
+#ifdef HS_BT_DEF_PIN
+        case PAL_PAD(HS_2G4_DEF_PIN): {
+            lpwr_set_sleep_wakeupcd(LPWR_WAKEUP_SWITCH);
+        } break;
+#endif
+
+#ifdef HS_2G4_DEF_PIN
+        case PAL_PAD(HS_BT_DEF_PIN): {
+            lpwr_set_sleep_wakeupcd(LPWR_WAKEUP_SWITCH);
+        } break;
+#endif
+        default: {
+
+        } break;
+    }
+}
+
+void lpwr_stop_hook_pre(void) {
+    if (is_keyboard_master()) {
+        gpio_write_pin_low(LED_POWER_EN_PIN);
+        gpio_write_pin_low(A9);
+    }
+
+    if (lower_sleep) {
+        md_send_devctrl(MD_SND_CMD_DEVCTRL_USB);
+        wait_ms(200);
+        lpwr_set_sleep_wakeupcd(LPWR_WAKEUP_UART);
+    }
+}
+
+void lpwr_stop_hook_post(void) {
+    if (lower_sleep) {
+        switch (lpwr_get_sleep_wakeupcd()) {
+            case LPWR_WAKEUP_USB:
+            case LPWR_WAKEUP_CABLE: {
+                lower_sleep = false;
+                lpwr_set_state(LPWR_WAKEUP);
+            } break;
+            default: {
+                lpwr_set_state(LPWR_STOP);
+            } break;
+        }
+    }
+}

--- a/keyboards/epomaker/split70/wls/wls.h
+++ b/keyboards/epomaker/split70/wls/wls.h
@@ -1,0 +1,31 @@
+#include QMK_KEYBOARD_H
+
+#include "quantum.h"
+#include <stdbool.h>
+#include "wireless.h"
+
+// #define HS_BT_DEF_PIN                     C14
+// #define HS_2G4_DEF_PIN                    C15
+// #define HS_BT_PIN_STATE                   0, 1
+// #define HS_2G4_PIN_STATE                  1, 0
+// #define HS_USB_PIN_STATE                  1, 1
+
+#define HS_GET_MODE_PIN_(pin_bt, pin_2g4) ((((#pin_bt)[0] == 'x') || ((readPin(HS_BT_DEF_PIN) + 0x30) == ((#pin_bt)[0]))) && (((#pin_2g4)[0] == 'x') || ((readPin(HS_2G4_DEF_PIN) + 0x30) == ((#pin_2g4)[0]))))
+#define HS_GET_MODE_PIN(state)            HS_GET_MODE_PIN_(state)
+#define HS_MODEIO_DETECTION_TIME          50
+#define HS_LBACK_TIMEOUT                  (30 * 1000)
+#define HS_SLEEP_TIMEOUT                  (1 * 60000) //(1 * 60000)
+
+enum modeio_mode {
+    hs_none = 0,
+    hs_usb,
+    hs_bt,
+    hs_2g4,
+    hs_wireless
+};
+
+extern bool lower_sleep;
+bool hs_rgb_blink_hook(void);
+bool hs_mode_scan(bool update, uint8_t moude, uint8_t lsat_btdev);
+bool hs_modeio_detection(bool update, uint8_t *mode, uint8_t lsat_btdev);
+void hs_rgb_blink_set_timer(uint32_t time);

--- a/keyboards/epomaker/split70/wls/wls.mk
+++ b/keyboards/epomaker/split70/wls/wls.mk
@@ -1,0 +1,1 @@
+SRC += wls/wls.c


### PR DESCRIPTION
Disclaimer: **This firmware is untested as I don't have the Split70 keyboard**. Parts of it were based on split65 due to missing configs.

I recommend having the original factory firmware in case reversion is needed. I also don't have the proper flashing procedure but it might be similar to split65 instructions here: https://github.com/carlosedp/qmk_firmware/tree/master/keyboards/epomaker/split65#flashing-instructions

[epomaker_split70_default.zip](https://github.com/user-attachments/files/30093820/epomaker_split70_default.zip)

Factory Firmware: 
[Epomaker_Split70_v23.zip](https://github.com/user-attachments/files/30093764/Epomaker_Split70_v23.zip)

